### PR TITLE
Adds admin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,24 @@ Discord via the following commands in any of the authorized channels.
 
 - `!help`: Provides detailed help about all of the following commands.
 - `!about`: Get information about SpellBot and its creators.
-- `!hello`: Gives you some good tidings.
+
+### ✋ Queueing
+
 - `!queue`: Get in line to play some Magic: The Gathering!
 - `!leave`: Get out of line; it's the opposite of `!queue`.
 
-## WIP: Commands
+### 👑 Administration
+
+- `!spellbot`: Admin commands to configure SpellBot for your server.
+
+#### ❗ Administration Subcommands
+
+- `channels`: Set the channels SpellBot is allowed to operate within.
+- `prefix`: Set the command prefix for SpellBot in text channels.
+
+## 🔮 Future Work
 
 ### Status
-
-As a DM to the bot:
 
 ```text
 !status
@@ -38,8 +47,6 @@ As a DM to the bot:
 - Possibly give you some status on your history of games and win/lose
 
 ### Reporting
-
-In a text channel:
 
 ```text
 !report win @username[, @username, @username, ...]
@@ -54,8 +61,6 @@ In a text channel:
 - Do we need a `!report loss` command for any reason?
 
 ### Moderation
-
-As a DM to the bot by an authorized user:
 
 ```text
 !ban @username <reason> [minutes]
@@ -107,12 +112,19 @@ As a DM to the bot by an authorized user:
 
 ### Concerns / Thoughts / Ideas
 
-- After a game is created, it needs to expire at some point
 - After a report is done, how long until the report command stops working
 - Does a user's game need to be reported before they can re-queue?
 - What happens if a game is never reported on?
 - When matchmaking w/ power levels, does it need to be a 100% match, +/- how much?
 - What about using ELO to match make?
+- Cleanup unused tags
+- Ask to confirm when added queue by a mention
+- User preferences:
+  - contact info
+  - default tags
+  - beta/prod
+  - etc...?
+- Limit the number of tags per game
 
 ## 🤖 Running SpellBot
 

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -1,10 +1,21 @@
 did_you_mean: 'Did you mean: $possible?'
+expired: SpellBot has removed you from the queue after waiting $window minutes to
+  try and match you up with other players. Sorry, but unfortunately not enough players
+  were found in that time. Please try again when there's more players available.
 leave: You have been removed from the queue.
 leave_already: You were not in the queue.
+no_dm: That command only works in text channels.
 not_a_command: Sorry, there is no "$request" command.
+not_admin: You do not have admin permissions for this bot.
 queue: You have been entered into the play queue.
 queue_already: You are already in the queue.
 queue_mention_already: Sorry, $user is already in the play queue.
 queue_ready: Your game is ready, go to $url to begin playing!
 queue_size_bad: Game size must be between 2 and 4.
 queue_too_many: Sorry, you mentioned too many people.
+spellbot_channels: 'This bot is now authroized to respond only in: $channels'
+spellbot_channels_none: Please provide a list of channels.
+spellbot_missing_subcommand: Please provide a subcommand when using this command.
+spellbot_prefix: This bot will now use "$prefix" as its command prefix for this server.
+spellbot_prefix_none: Please provide a prefix string.
+spellbot_unknown_subcommand: The subcommand "$command" is not recognized.

--- a/src/spellbot/versions/versions/06c86186ed07_use_guild_xid_for_external_guild_id.py
+++ b/src/spellbot/versions/versions/06c86186ed07_use_guild_xid_for_external_guild_id.py
@@ -1,0 +1,24 @@
+"""Use guild_xid for external guild id
+
+Revision ID: 06c86186ed07
+Revises: 36a0bdecd043
+Create Date: 2020-07-02 13:00:34.468798
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "06c86186ed07"
+down_revision = "36a0bdecd043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("authorized_channels") as b:
+        b.alter_column("guild", new_column_name="guild_xid")
+
+
+def downgrade():
+    with op.batch_alter_table("authorized_channels") as b:
+        b.alter_column("guild_xid", new_column_name="guild")

--- a/src/spellbot/versions/versions/36a0bdecd043_utc_default_created_at.py
+++ b/src/spellbot/versions/versions/36a0bdecd043_utc_default_created_at.py
@@ -1,0 +1,33 @@
+"""UTC default created_at
+
+Revision ID: 36a0bdecd043
+Revises: 4ae86dc1a1c6
+Create Date: 2020-07-02 12:16:55.784924
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "36a0bdecd043"
+down_revision = "4ae86dc1a1c6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("games") as b:
+        b.alter_column(
+            "created_at",
+            existing_server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            server_default=None,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("games") as b:
+        b.alter_column(
+            "created_at",
+            existing_server_default=None,
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+        )

--- a/src/spellbot/versions/versions/4c58ac289115_add_bot_prefixes_table.py
+++ b/src/spellbot/versions/versions/4c58ac289115_add_bot_prefixes_table.py
@@ -1,0 +1,29 @@
+"""Add bot_prefixes table
+
+Revision ID: 4c58ac289115
+Revises: 06c86186ed07
+Create Date: 2020-07-02 13:43:51.218180
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4c58ac289115"
+down_revision = "06c86186ed07"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "bot_prefixes",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("guild_xid", sa.BigInteger(), nullable=False),
+        sa.Column("prefix", sa.String(length=10), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("bot_prefixes")

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -3,16 +3,29 @@ __**SpellBot Usage**__
 **!about**
 >  Get information about SpellBot.
 
-**!hello**
->  Says hello.
-
 **!help**
->  Shows this help screen.
+>  Sends you this help message.
 
 **!leave**
 >  Leave your place in the queue.
 
 **!queue** _[@mention-1] [@mention-2] [...] [size:N] [tag-1] [tag-2] [...]_
->  Enter the queue for a game on SpellTable.  You can get in the queue with a friend by including them in the command with as many @ mentions as you want. You can also choose the number of players by using `size:2` for a two player game, for example. The default number of players is 4.  You can also give a list of tags and you will only be matched against users who have the same tags as you. For example, if you want to enter into a cEDH queue you could try `!queue cEDH`. Check with your server for supported tags.
+>  Enter the queue for a game on SpellTable.
+> 
+> You can get in the queue with a friend by including them in the command with as
+> many @ mentions as you want. You can also choose the number of players by using
+> `size:2` for a two player game, for example. The default number of players is 4.
+> 
+> You can also give a list of tags and you will only be matched against users who
+> have the same tags as you. For example, if you want to enter into a cEDH queue
+> you could try `queue cEDH`. Check with your server for supported tags. A valid
+> tag can not be just a number, like `10` for example, nor can it be longer than
+> 50 characters.
+
+**!spellbot** _<subcommand> [subcommand parameters]_
+>  Configure SpellBot for your server. Use with one of the following subcommands:
+> 
+> - channel <list>: Set SpellBot to only respond in the given list of channels
+> - prefix <string>: Set SpellBot prefix for commands in text channels
 
 _SpellBot created by amy@lexicalunit.com_

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,6 @@ max-line-length = 90
 
 [pytest]
 addopts =
-    --disable-pytest-warnings
     --ignore=tests/fixtures
     --ignore=tests/snapshots
+    -W ignore::DeprecationWarning


### PR DESCRIPTION
**Description**

- Clean up old games after 30 minutes of waiting
- Allow SpellBot Admin roles to administer SpellBot
- `!spellbot channels` to set the list of channels the bot can use
- `!spellbot prefix` to se the bot's command prefix

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
