### PR TITLE
Adds channel scope support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Discord via the following commands in any of the authorized channels.
 
 - `channels`: Set the channels SpellBot is allowed to operate within.
 - `prefix`: Set the command prefix for SpellBot in text channels.
+- `scope`: Set the matchmaking scope to server-wide or channel-specific.
 
 ## 🙌 Support Me
 

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -21,6 +21,9 @@ spellbot_channels_none: Please provide a list of channels.
 spellbot_missing_subcommand: Please provide a subcommand when using this command.
 spellbot_prefix: This bot will now use "$prefix" as its command prefix for this server.
 spellbot_prefix_none: Please provide a prefix string.
+spellbot_scope: 'Matchmaking on this server is now set to: $scope.'
+spellbot_scope_bad: Sorry, scope should be either "server" or "channel".
+spellbot_scope_none: Please provide a scope string.
 spellbot_unknown_subcommand: The subcommand "$command" is not recognized.
 status: The average queue wait time is currently $average seconds.
 status_unknown: There is not enough information to calculate the current average queue

--- a/src/spellbot/versions/versions/95d019d132f5_wait_time_by_channel_scope.py
+++ b/src/spellbot/versions/versions/95d019d132f5_wait_time_by_channel_scope.py
@@ -1,0 +1,25 @@
+"""Wait time by channel scope
+
+Revision ID: 95d019d132f5
+Revises: aae06e464fc4
+Create Date: 2020-07-03 13:57:34.728319
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "95d019d132f5"
+down_revision = "aae06e464fc4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("wait_times") as b:
+        b.add_column(sa.Column("channel_xid", sa.BigInteger()))
+
+
+def downgrade():
+    with op.batch_alter_table("wait_times") as b:
+        b.drop_column("channel_xid")

--- a/src/spellbot/versions/versions/aae06e464fc4_servers_table.py
+++ b/src/spellbot/versions/versions/aae06e464fc4_servers_table.py
@@ -1,0 +1,38 @@
+"""Servers table
+
+Revision ID: aae06e464fc4
+Revises: 2ad0a1c189cc
+Create Date: 2020-07-03 13:44:21.203939
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "aae06e464fc4"
+down_revision = "2ad0a1c189cc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "servers",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("guild_xid", sa.BigInteger(), nullable=False),
+        sa.Column("prefix", sa.String(length=10), nullable=False),
+        sa.Column("scope", sa.String(length=10), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.drop_table("bot_prefixes")
+
+
+def downgrade():
+    op.create_table(
+        "bot_prefixes",
+        sa.Column("id", sa.INTEGER(), nullable=False),
+        sa.Column("guild_xid", sa.BIGINT(), nullable=False),
+        sa.Column("prefix", sa.VARCHAR(length=10), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.drop_table("servers")

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -21,12 +21,17 @@ __**SpellBot Usage**__
 > you could try `queue cEDH`. Check with your server for supported tags. A valid
 > tag can not be just a number, like `10` for example, nor can it be longer than
 > 50 characters.
+> 
+> If the scope for your server is set to "channel" then matchmaking will only happen
+> between other players who alos enter the queue in the same channel as yourself.
+> The default scope however is server wide.
 
 **!spellbot** _<subcommand> [subcommand parameters]_
 >  Configure SpellBot for your server. Use with one of the following subcommands:
 > 
 > - channel <list>: Set SpellBot to only respond in the given list of channels
 > - prefix <string>: Set SpellBot prefix for commands in text channels
+> - scope [server|channel]: Set matchmaking scope to server-wide or channel-only
 
 **!status**
 >  Show some details about the queues on your server.


### PR DESCRIPTION
**Description**

Adds admin command:

`!spellbot scope [server|channel]`

The default setting is `server`. When changed to `channel` the `!play` queues will be specific to each channel on the server.

- Resolves #20

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [ ] Entire test suite passes
