### PR TITLE
Handle games_tags rows, add config admin cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ A Discord bot for [SpellTable][spelltable].
 ## 🤖 Using SpellBot
 
 Once you've connected the bot to your server, you can interact with it over
-Discord via the following commands in any of the authorized channels.
+Discord via the following commands in any of the authorized channels. **Keep in
+mind that sometimes SpellBot will respond to you via Direct Message to avoid
+being too spammy in text channels.**
 
 - `!help`: Provides detailed help about all of the following commands.
 - `!about`: Get information about SpellBot and its creators.
@@ -35,6 +37,7 @@ Discord via the following commands in any of the authorized channels.
 
 **Subcommands:**
 
+- `config`: Just show the current configuration for this server.
 - `channels`: Set the channels SpellBot is allowed to operate within.
 - `prefix`: Set the command prefix for SpellBot in text channels.
 - `scope`: Set the matchmaking scope to server-wide or channel-specific.

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -36,8 +36,8 @@
 > 
 > The following subcommands are supported:
 > 
+> * `config`: Just show the current configuration for this server.
 > * `channel <list>`: Set SpellBot to only respond in the given list of channels.
 > * `prefix <string>`: Set SpellBot prefix for commands in text channels.
 > * `scope <server|channel>`: Set matchmaking scope to server-wide or channel-only.
 > * `expire <number>`: Set the number of minutes before pending games expire.
-> 

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,3 +1,4 @@
+> 
 > _You must have the "SpellBot Admin" role to use any of these commands._
 
 `!status`


### PR DESCRIPTION
**Description**

Handle cleanup of rows in `games_tags` properly. Also adds the `!spellbot conifg` admin command.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [ ] Entire test suite passes
