### PR TITLE
Change user.xid to primary key

### DIFF
--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -103,8 +103,7 @@ games_tags = Table(
 
 class User(Base):
     __tablename__ = "users"
-    id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
-    xid = Column(BigInteger, nullable=False)
+    xid = Column(BigInteger, primary_key=True, nullable=False)
     game_id = Column(Integer, ForeignKey("games.id", ondelete="SET NULL"), nullable=True)
     queued_at = Column(DateTime, nullable=True)
     game = relationship("Game", back_populates="users")

--- a/src/spellbot/versions/versions/ee2447c63f27_use_xid_as_primary_user_key.py
+++ b/src/spellbot/versions/versions/ee2447c63f27_use_xid_as_primary_user_key.py
@@ -1,0 +1,58 @@
+"""Use xid as primary user key
+
+Revision ID: ee2447c63f27
+Revises: 7e8e700f965c
+Create Date: 2020-07-09 16:48:13.534994
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ee2447c63f27"
+down_revision = "7e8e700f965c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "tmp",
+        sa.Column("xid", sa.BigInteger(), nullable=False),
+        sa.Column("game_id", sa.Integer(), nullable=True),
+        sa.Column("queued_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["game_id"], ["games.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("xid"),
+    )
+    conn = op.get_bind()
+    conn.execute(
+        """
+        INSERT INTO tmp (xid, game_id, queued_at)
+        SELECT xid, game_id, queued_at
+        FROM users;
+    """
+    )
+    op.drop_table("users")
+    op.rename_table("tmp", "users")
+
+
+def downgrade():
+    op.create_table(
+        "tmp",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("xid", sa.BigInteger(), nullable=False),
+        sa.Column("game_id", sa.Integer(), nullable=True),
+        sa.Column("queued_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["game_id"], ["games.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    conn = op.get_bind()
+    conn.execute(
+        """
+        INSERT INTO tmp (xid, game_id, queued_at)
+        SELECT xid, game_id, queued_at
+        FROM users;
+    """
+    )
+    op.drop_table("users")
+    op.rename_table("tmp", "users")


### PR DESCRIPTION
**Description**

Migrate `users` table to a new table where `xid` is the primary key instead of an auto-incrementing integer.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
