### PR TITLE
Adds optional message to event command

### DIFF
--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -590,7 +590,8 @@ class SpellBot(discord.Client):
         Games will not be created immediately. This is to allow you to verify things look
         ok. This command will also give you directions on how to actually start the games
         for this event as part of its reply.
-        & <player 1 column> <player 2 column> ... <player N column>
+        * Optional: Add a message by using " -- " followed by the message content.
+        & <column 1> <column 2> ... <column 3> [-- An optional message to add.]
         """
         if not is_admin(message.channel, message.author):
             return await message.channel.send(s("not_admin"))
@@ -600,6 +601,17 @@ class SpellBot(discord.Client):
 
         if not params:
             return await message.channel.send(s("event_no_params"))
+
+        optional_message = None
+        try:
+            sentry = params.index("--")
+            optional_message = " ".join(params[sentry + 1 :])
+            params = params[0:sentry]
+        except ValueError:
+            pass
+
+        if optional_message and len(optional_message) >= 255:
+            return await message.channel.send(s("game_message_too_long"))
 
         size = len(params)
         if not (1 < size <= 4):
@@ -679,6 +691,7 @@ class SpellBot(discord.Client):
                 size=size,
                 updated_at=now,
                 status="ready",
+                message=optional_message,
                 users=player_users,
                 event=event,
             )

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -5,12 +5,13 @@
 `!begin <event id>`
 >  Confirm creation of games for the given event id. _Requires the "SpellBot Admin" role._
 
-`!event <player 1 column> <player 2 column> ... <player N column>`
+`!event <column 1> <column 2> ... <column 3> [-- An optional message to add.]`
 >  Create many games in batch from an attached CSV data file. _Requires the "SpellBot Admin" role._
 > 
 > For example, if your event is for a Modern tournement you might attach a CSV file with a comment like `!event Player1Username Player2Username`. This would assume that the players' discord user names are found in the "Player1Username" and "Player2Username" CSV columns. The game size is deduced from the number of column names given, so we know the games created in this example are `size:2`.
 > 
 > Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
+> * Optional: Add a message by using " -- " followed by the message content.
 
 `!game [similar parameters as !play] [-- An optional additional message to send.]`
 >  Create a game between mentioned users. _Requires the "SpellBot Admin" role._
@@ -29,4 +30,4 @@
 `!play [@mention-1] [@mention-2] [...] [size:N] [power:N] [tag-1] [tag-2] [...]`
 >  Enter a play queue for a game on SpellTable.
 > 
-> You can get in a queue with a friend by mentioning them in the command with the @ character. You can also change the number of players from the default of four by using, for example, `!play size:2` to create a two player game.
+> You can get in a queue with a friend by mentioning them in the command with the @ character.

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,3 +1,5 @@
+>  You can also change the number of players from the default of four by using, for example, `!play size:2` to create a two player game.
+> 
 > Up to five tags can be given as well. For example, `!play no-combo proxy` has two tags: `no-combo` and `proxy`. Look on your server for what tags are being used by your community members. Tags can **not** be a number like `5`. Be careful when using tags because the matchmaker will only pair you up with other players who've used **EXACTLY** the same tags.
 > 
 > You can also specify a power level like `!play power:7` for example and the matchmaker will attempt to find a game with similar power levels for you. Note that players who specify a power level will never get paired up with players who have not, and vice versa. You will also not be matched up _exactly_ by power level as there is a fudge factor involved.


### PR DESCRIPTION
**Description**

Adds the ability to `-- add an optional message override` to the message that SpellBot sends to players over direct message when their game is ready to the `!event` command. Works just like it does in the `!game` command.

- Resolves #51 

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
