### PR TITLE
Adds a spellbot setting for friendly server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ being too spammy in text channels.**
   - `prefix`: Set the command prefix for SpellBot in text channels.
   - `scope`: Set the matchmaking scope to server-wide or channel-specific.
   - `expire`: Set how many minutes before games are expired due to inactivity.
+  - `friendly`: Allow or disallow friendly queueing with mentions.
 
 ## 🙌 Support Me
 

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -54,6 +54,9 @@ spellbot_channels_none: Please provide a list of channels.
 spellbot_expire: Game expiration time set to $expire minutes.
 spellbot_expire_bad: Sorry, game expiration time should be between 10 and 60 minutes.
 spellbot_expire_none: Please provide a number of minutes.
+spellbot_friendly: 'Allow users to queue with their friends: $friendly.'
+spellbot_friendly_bad: Sorry, this setting should be either "off" or "on".
+spellbot_friendly_none: Please indicate either "off" or "on".
 spellbot_missing_subcommand: Please provide a subcommand when using this command.
 spellbot_prefix: This bot will now use "$prefix" as its command prefix for this server.
 spellbot_prefix_none: Please provide a prefix string.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -7,6 +7,7 @@ import alembic.config
 from humanize import naturaldelta
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     Column,
     DateTime,
     Float,
@@ -69,6 +70,7 @@ class Server(Base):
     prefix = Column(String(10), nullable=False, default="!")
     scope = Column(String(10), nullable=False, default="server")
     expire = Column(Integer, nullable=False, server_default=text("30"))  # minutes
+    friendly = Column(Boolean)  # Note that unset means that friendly is ON!
     games = relationship("Game", back_populates="server")
     authorized_channels = relationship("Channel", back_populates="server")
 
@@ -79,6 +81,7 @@ class Server(Base):
                 "prefix": self.prefix,
                 "scope": self.scope,
                 "expire": self.expire,
+                "friendly": self.friendly if self.friendly is not None else True,
             }
         )
 

--- a/src/spellbot/versions/versions/64d847efbe4a_add_friendly_column_to_servers_table.py
+++ b/src/spellbot/versions/versions/64d847efbe4a_add_friendly_column_to_servers_table.py
@@ -1,0 +1,25 @@
+"""Add friendly column to servers table
+
+Revision ID: 64d847efbe4a
+Revises: db42410953c4
+Create Date: 2020-07-11 16:11:04.621100
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "64d847efbe4a"
+down_revision = "db42410953c4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("servers") as b:
+        b.add_column(sa.Column("friendly", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("servers") as b:
+        b.drop_column("friendly")

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -15,6 +15,7 @@
 > * `prefix <string>`: Set SpellBot prefix for commands in text channels.
 > * `scope <server|channel>`: Set matchmaking scope to server-wide or channel-only.
 > * `expire <number>`: Set the number of minutes before pending games expire.
+> * `friendly <on|off>`: Allow or disallow friendly queueing with mentions.
 
 `!status`
 >  Show some details about the queues on your server.

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -1184,6 +1184,7 @@ class TestSpellBot:
         )
         fields = {f["name"]: f["value"] for f in about["fields"]}
         assert fields["Queue scope"] == "channel-specific"
+        assert fields["Friendly queueing"] == "on"
         assert fields["Inactivity expiration time"] == "45 minutes"
         assert fields["Authorized channels"] == "all"
 
@@ -1369,6 +1370,7 @@ class TestSpellBot:
             "prefix": "!",
             "scope": "server",
             "expire": 30,
+            "friendly": True,
         }
 
     async def test_on_message_event_no_data(self, client):
@@ -1682,6 +1684,32 @@ class TestSpellBot:
         await client.on_message(MockMessage(an_admin(), channel, f"!begin {event_id}"))
         assert channel.last_sent_response == (
             "Sorry, that event has already started and can not be started again."
+        )
+
+    async def test_on_message_spellbot_friendly_none(self, client):
+        author = an_admin()
+        channel = text_channel()
+        await client.on_message(MockMessage(author, channel, "!spellbot friendly"))
+        assert channel.last_sent_response == 'Please indicate either "off" or "on".'
+
+    async def test_on_message_spellbot_friendly_bad(self, client):
+        author = an_admin()
+        channel = text_channel()
+        await client.on_message(MockMessage(author, channel, "!spellbot friendly world"))
+        assert channel.last_sent_response == (
+            'Sorry, this setting should be either "off" or "on".'
+        )
+
+    async def test_on_message_spellbot_friendly(self, client):
+        author = an_admin()
+        channel = text_channel()
+        await client.on_message(MockMessage(author, channel, "!spellbot friendly off"))
+        assert channel.last_sent_response == (
+            "Allow users to queue with their friends: off."
+        )
+        await client.on_message(MockMessage(author, channel, "!spellbot friendly on"))
+        assert channel.last_sent_response == (
+            "Allow users to queue with their friends: on."
         )
 
 


### PR DESCRIPTION
**Description**

Allow server admins to disable the ability for users to `!play @someone-else` other people.

- Resolves #53 

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
