### PR TITLE
Cache user names on event command

### DIFF
--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -122,6 +122,7 @@ class User(Base):
     xid = Column(BigInteger, primary_key=True, nullable=False)
     game_id = Column(Integer, ForeignKey("games.id", ondelete="SET NULL"), nullable=True)
     queued_at = Column(DateTime, nullable=True)
+    cached_name = Column(String(50))
     game = relationship("Game", back_populates="users")
 
     @property

--- a/src/spellbot/versions/versions/1013ebad5050_add_cached_name_column_to_users.py
+++ b/src/spellbot/versions/versions/1013ebad5050_add_cached_name_column_to_users.py
@@ -1,0 +1,25 @@
+"""Add cached name column to users
+
+Revision ID: 1013ebad5050
+Revises: 64d847efbe4a
+Create Date: 2020-07-12 11:38:24.867699
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1013ebad5050"
+down_revision = "64d847efbe4a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("users") as b:
+        b.add_column(sa.Column("cached_name", sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("users") as b:
+        b.drop_column("cached_name")

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -1609,7 +1609,7 @@ class TestSpellBot:
         assert channel.last_sent_response == (
             f"**Game {game['id']} created:**\n"
             f"> {game['url']}\n"
-            f"> Players: <@{AMY.id}>, <@{JR.id}>"
+            f"> Players: {AMY.name}, {JR.name}"
         )
         player_response = game_response_for(client, AMY, True)
         assert AMY.last_sent_response == player_response
@@ -1635,7 +1635,7 @@ class TestSpellBot:
         assert channel.last_sent_response == (
             f"**Game {game['id']} created:**\n"
             f"> {game['url']}\n"
-            f"> Players: <@{AMY.id}>, <@{JR.id}>"
+            f"> Players: {AMY.name}, {JR.name}"
         )
         player_response = game_response_for(client, AMY, True, message=opt)
         assert AMY.last_sent_response == player_response
@@ -1663,7 +1663,7 @@ class TestSpellBot:
         assert channel.last_sent_response == (
             "**Warning:** A user left the server since this event was created."
             " SpellBot did **NOT** start the game for the players:"
-            f" <@{AMY.id}>, <@{JR.id}>."
+            f" {AMY.name}, {JR.name}."
         )
 
     async def test_on_message_begin_event_already(self, client):


### PR DESCRIPTION
**Description**

Cache discord user names on `!event` command so that we have them if there's any errors when the corresponding `!begin` command is run.

- Resolves #50 

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
