### PR TITLE
Completely refactors the user flow for creating games

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,32 @@ being too spammy in text channels.**
 - `!help`: Provides detailed help about all of the following commands.
 - `!about`: Get information about SpellBot and its creators.
 
-### ✋ Matchmaking
+### ✋ Looking For Game
 
-- `!play`: Get in line to play some Magic: The Gathering!
-- `!leave`: Get out of line; it's the opposite of `!play`.
-- `!status`: Show some details about the queues on your server.
+For players just looking to start some games, these commands are for you!
 
-### 👑 Administration
+- `!lfg`: Create a pending game for people join.
+- `!leave`: Leave any pending games that you've signed up for.
+
+### 🎟️ Commands for Event Runners
+
+These commands are intended to be run by SpellBot Admins and help facilitate
+online events.
 
 - `!game`: Directly create games for the mentioned users.
 - `!event`: Create a bunch of games all at once based on some uploaded data.
 - `!begin`: Start an event that you previously created with `!event`.
+
+### 👑 Administrative Commands
+
+These commands will help you configure SpellBot for your server.
+
 - `!spellbot`: This command allows admins to configure SpellBot for their
                server. It supports the following subcommands:
   - `config`: Just show the current configuration for this server.
   - `channels`: Set the channels SpellBot is allowed to operate within.
   - `prefix`: Set the command prefix for SpellBot in text channels.
-  - `scope`: Set the matchmaking scope to server-wide or channel-specific.
   - `expire`: Set how many minutes before games are expired due to inactivity.
-  - `friendly`: Allow or disallow friendly queueing with mentions.
 
 ## 🙌 Support Me
 
@@ -89,7 +96,7 @@ You can also run SpellBot via docker. See
 
 [MIT][mit] © [amy@lexicalunit][lexicalunit] et [al][contributors]
 
-[add-bot]:            https://discordapp.com/api/oauth2/authorize?client_id=725510263251402832&permissions=247872&scope=bot
+[add-bot]:            https://discordapp.com/api/oauth2/authorize?client_id=725510263251402832&permissions=92224&scope=bot
 [add-img]:            https://user-images.githubusercontent.com/1903876/82262797-71745100-9916-11ea-8b65-b3f656115e4f.png
 [black-badge]:        https://img.shields.io/badge/code%20style-black-000000.svg
 [black]:              https://github.com/psf/black

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -22,48 +22,36 @@ event_no_params: Please include the column names from the CSV file too identify 
   players' discord names.
 event_not_csv: Sorry, the file is not a CSV file. Make sure the filename ends with
   ".csv" please.
-expired: SpellBot has removed you from the queue due to server inactivity. Sorry,
-  but unfortunately not enough players available at this time. Please try again when
-  there are more players available.
+expired: SpellBot has deleted your pending game due to server inactivity.
 game_created: '**Game $id created:**
 
   > $url
 
   > Players notified by DM: $players'
 game_message_too_long: Sorry, the optional game message must be shorter than 255 characters.
-game_power_bad: Sorry, power level should a number between 1 and 10.
 game_size_bad: Game size must be between 2 and 4.
 game_too_few_mentions: Sorry, you mentioned too few people. I expected $size players
   to be mentioned.
 game_too_many_mentions: Sorry, you mentioned too many people. I expected $size players
   to be mentioned.
 game_too_many_tags: Sorry, you can not use more than 5 tags.
-leave: You have been removed from the queue.
-leave_already: You were not in the queue.
+leave: You've been removed from the pending game that you were signed up for.
+leave_already: You we're not in any pending games.
+lfg_already: You're already in a pending game. If you want to, you can leave all games
+  with `${prefix}leave`.
+lfg_size_bad: Sorry, game size should be between 2 and 4.
+lfg_too_many_tags: Sorry, you can not use more than 5 tags.
 no_dm: That command only works in text channels.
 not_a_command: Sorry, there is no "$request" command.
 not_admin: You do not have admin permissions for this bot.
-play_already: You are already in the queue.
-play_mention_already: Sorry, $user is already in the play queue.
-play_power_bad: Sorry, power level should a number between 1 and 10.
-play_size_bad: Game size must be between 2 and 4.
-play_too_many_mentions: Sorry, you mentioned too many people.
-play_too_many_tags: Sorry, you can not use more than 5 tags.
-spellbot_channels: 'This bot is now authroized to respond only in: $channels'
+react_already_in: Sorry, I couldn't add you to that game because you're already signed
+  up for another game. You can use `${prefix}leave` to leave that game.
+spellbot_channels: 'This bot is now authorized to respond only in: $channels'
 spellbot_channels_none: Please provide a list of channels.
 spellbot_expire: Game expiration time set to $expire minutes.
 spellbot_expire_bad: Sorry, game expiration time should be between 10 and 60 minutes.
 spellbot_expire_none: Please provide a number of minutes.
-spellbot_friendly: 'Allow users to queue with their friends: $friendly.'
-spellbot_friendly_bad: Sorry, this setting should be either "off" or "on".
-spellbot_friendly_none: Please indicate either "off" or "on".
 spellbot_missing_subcommand: Please provide a subcommand when using this command.
 spellbot_prefix: This bot will now use "$prefix" as its command prefix for this server.
 spellbot_prefix_none: Please provide a prefix string.
-spellbot_scope: 'Matchmaking on this server is now set to: $scope.'
-spellbot_scope_bad: Sorry, scope should be either "server" or "channel".
-spellbot_scope_none: Please provide a scope string.
 spellbot_unknown_subcommand: The subcommand "$command" is not recognized.
-status: The average queue wait time is currently $wait.
-status_unknown: There is not enough information to calculate the current average queue
-  wait time right now.

--- a/src/spellbot/constants.py
+++ b/src/spellbot/constants.py
@@ -1,5 +1,4 @@
 # Application Settings
 ADMIN_ROLE = "SpellBot Admin"
 CREATE_ENDPOINT = "https://us-central1-magic-night-30324.cloudfunctions.net/createGame"
-AVG_QUEUE_TIME_WINDOW_MIN = 30
 THUMB_URL = "https://raw.githubusercontent.com/lexicalunit/spellbot/master/spellbot.png"

--- a/src/spellbot/versions/versions/0a01d60d4c38_removing_cruft_since_refactor.py
+++ b/src/spellbot/versions/versions/0a01d60d4c38_removing_cruft_since_refactor.py
@@ -1,0 +1,39 @@
+"""Removing cruft since refactor
+
+Revision ID: 0a01d60d4c38
+Revises: d5208ea8d47f
+Create Date: 2020-07-15 13:36:01.602982
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0a01d60d4c38"
+down_revision = "d5208ea8d47f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table("wait_times")
+    with op.batch_alter_table("games") as b:
+        b.drop_column("power")
+    with op.batch_alter_table("users") as b:
+        b.drop_column("queued_at")
+
+
+def downgrade():
+    with op.batch_alter_table("users") as b:
+        b.add_column(sa.Column("queued_at", sa.DATETIME(), nullable=True))
+    with op.batch_alter_table("games") as b:
+        b.add_column(sa.Column("power", sa.FLOAT(), nullable=True))
+    op.create_table(
+        "wait_times",
+        sa.Column("id", sa.INTEGER(), nullable=False),
+        sa.Column("guild_xid", sa.BIGINT(), nullable=False),
+        sa.Column("channel_xid", sa.BIGINT(), nullable=False),
+        sa.Column("created_at", sa.DATETIME(), nullable=False),
+        sa.Column("seconds", sa.INTEGER(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )

--- a/src/spellbot/versions/versions/d5208ea8d47f_refactor_to_replace_queue_logic_with_lfg.py
+++ b/src/spellbot/versions/versions/d5208ea8d47f_refactor_to_replace_queue_logic_with_lfg.py
@@ -1,0 +1,27 @@
+"""Refactor to replace queue logic with lfg
+
+Revision ID: d5208ea8d47f
+Revises: 6a1ea19d138f
+Create Date: 2020-07-15 12:51:40.082517
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d5208ea8d47f"
+down_revision = "6a1ea19d138f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("servers") as b:
+        b.drop_column("friendly")
+        b.drop_column("scope")
+
+
+def downgrade():
+    with op.batch_alter_table("servers") as b:
+        b.add_column(sa.Column("scope", sa.VARCHAR(length=10), nullable=False))
+        b.add_column(sa.Column("friendly", sa.BOOLEAN(), nullable=True))

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -13,10 +13,10 @@
 > Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
 > * Optional: Add a message by using " -- " followed by the message content.
 
-`!game [similar parameters as !play] [-- An optional additional message to send.]`
+`!game [similar parameters as !lfg] [-- An optional additional message to send.]`
 >  Create a game between mentioned users. _Requires the "SpellBot Admin" role._
 > 
-> Operates similarly to the `!play` command with a few key deferences. First, see that command's usage help for more details. Then, here are the differences:
+> Operates similarly to the `!lfg` command with a few key deferences. First, see that command's usage help for more details. Then, here are the differences:
 > * The user who issues this command is **NOT** added to the game themselves.
 > * You must mention all of the players to be seated in the game.
 > * Optional: Add a message by using " -- " followed by the message content.
@@ -25,9 +25,9 @@
 >  Sends you this help message.
 
 `!leave`
->  Leave your place in the queue.
+>  Leave any pending game that you've signed up for on this server.
 
-`!play [@mention-1] [@mention-2] [...] [size:N] [power:N] [tag-1] [tag-2] [...]`
->  Enter a play queue for a game on SpellTable.
+`!lfg [size:N] [tag-1] [tag-2] [...] [tag-N]`
+>  Create a pending game for players to join.
 > 
-> You can get in a queue with a friend by mentioning them in the command with the @ character.
+> The default game size is 4 but you can change it by adding, for example, `size:2` to create a two player game.

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,10 +1,6 @@
->  You can also change the number of players from the default of four by using, for example, `!play size:2` to create a two player game.
+> Players will be able to join or leave the game by reacting to the message that SpellBot sends with the ➕ and ➖ emoji.
 > 
-> Up to five tags can be given as well. For example, `!play no-combo proxy` has two tags: `no-combo` and `proxy`. Look on your server for what tags are being used by your community members. Tags can **not** be a number like `5`. Be careful when using tags because the matchmaker will only pair you up with other players who've used **EXACTLY** the same tags.
-> 
-> You can also specify a power level like `!play power:7` for example and the matchmaker will attempt to find a game with similar power levels for you. Note that players who specify a power level will never get paired up with players who have not, and vice versa. You will also not be matched up _exactly_ by power level as there is a fudge factor involved.
-> 
-> If your server's admins have set the scope for your server to "channel", then matchmaking will only happen between other players who run this command in the same channel as you did. The default scope for matchmaking is server-wide.
+> Up to five tags can be given as well to help describe the game expereince that you want. For example you might send `!lfg no-combo proxy` which will assign the tags: `no-combo` and `proxy` to your game. People will be able to see what tags are set on your game when they are looking for games to join.
 
 `!spellbot <subcommand> [subcommand parameters]`
 >  Configure SpellBot for your server. _Requires the "SpellBot Admin" role._
@@ -13,12 +9,7 @@
 > * `config`: Just show the current configuration for this server.
 > * `channel <list>`: Set SpellBot to only respond in the given list of channels.
 > * `prefix <string>`: Set SpellBot prefix for commands in text channels.
-> * `scope <server|channel>`: Set matchmaking scope to server-wide or channel-only.
 > * `expire <number>`: Set the number of minutes before pending games expire.
-> * `friendly <on|off>`: Allow or disallow friendly queueing with mentions.
-
-`!status`
->  Show some details about the queues on your server.
 --- 
 Please report any bugs and suggestions at <https://github.com/lexicalunit/spellbot/issues>!
 


### PR DESCRIPTION
**Description**

This PR completely refactors how users look for games. It removes the `!play` command and the notion of queues and matchmaking entirely. Now users will use a `!lfg` (looking for game) command to prompt SpellBot to post an embed to the channel with details about the pending game. Other users will be able to join and leave the game by reacting to emojis on that post.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [x] Entire test suite passes
