### PR TITLE
Handling reaction remove is problematic

### DIFF
--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -165,10 +165,11 @@ class Game(Base):
             embed.description = (
                 f"Click the link below to join your SpellTable game.\n<{self.url}>"
             )
-            players = ", ".join(sorted([f"<@{user.xid}>" for user in self.users]))
-            embed.add_field(name="Players", value=players)
         else:
             embed.description = "To join/leave this game, react with ➕/➖."
+        if self.users:
+            players = ", ".join(sorted([f"<@{user.xid}>" for user in self.users]))
+            embed.add_field(name="Players", value=players)
         tag_names = None
         if not (len(self.tags) == 1 and self.tags[0].name == "default"):
             tag_names = ", ".join(sorted([tag.name for tag in self.tags]))


### PR DESCRIPTION
**Description**

Handling reaction removes causes chain reactions that are difficult to reason about. Maybe this can be supported in the future but for now it's easier to just rely on user's hitting the `-` button to be removed from a game.

This PR also contains some fixes for handling CSV files in `!event`.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [x] Entire test suite passes
