### PR TITLE
Adds invite support to lfg command

### DIFF
--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -35,11 +35,20 @@ game_too_few_mentions: Sorry, you mentioned too few people. I expected $size pla
 game_too_many_mentions: Sorry, you mentioned too many people. I expected $size players
   to be mentioned.
 game_too_many_tags: Sorry, you can not use more than 5 tags.
+invite_already_confirmed: Your invitation has already been confirmed.
+invite_confirmed: Thanks, your invitation has been confirmed!
+invite_denied: Thank you for your response.
+invite_not_invited: Sorry, you do not currently have any pending invitations.
 leave: You've been removed from the pending game that you were signed up for.
 leave_already: You we're not in any pending games.
 lfg_already: You're already in a pending game. If you want to, you can leave all games
   with `${prefix}leave`.
+lfg_invited: You've been invtied to a game by $mention. To confirm or deny please
+  respond with yes or no.
+lfg_mention_already: Sorry, but $mention is already in another pending game and can't
+  be invited.
 lfg_size_bad: Sorry, game size should be between 2 and 4.
+lfg_too_many_mentions: Sorry, you've mentioned too many players for this size game.
 lfg_too_many_tags: Sorry, you can not use more than 5 tags.
 no_dm: That command only works in text channels.
 not_a_command: Sorry, there is no "$request" command.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -7,6 +7,7 @@ import alembic.config
 import discord
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     Column,
     DateTime,
     ForeignKey,
@@ -91,6 +92,8 @@ class User(Base):
     xid = Column(BigInteger, primary_key=True, nullable=False)
     game_id = Column(Integer, ForeignKey("games.id", ondelete="SET NULL"), nullable=True)
     cached_name = Column(String(50))
+    invited = Column(Boolean, server_default=text("false"), nullable=False)
+    invite_confirmed = Column(Boolean, server_default=text("false"), nullable=False)
     game = relationship("Game", back_populates="users")
 
     @property

--- a/src/spellbot/versions/versions/18b8b53f9202_support_lfg_invites.py
+++ b/src/spellbot/versions/versions/18b8b53f9202_support_lfg_invites.py
@@ -1,0 +1,38 @@
+"""Support lfg invites
+
+Revision ID: 18b8b53f9202
+Revises: 0a01d60d4c38
+Create Date: 2020-07-17 11:10:19.106275
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "18b8b53f9202"
+down_revision = "0a01d60d4c38"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("users") as b:
+        b.add_column(
+            sa.Column(
+                "invite_confirmed",
+                sa.Boolean(),
+                server_default=sa.text("false"),
+                nullable=False,
+            ),
+        )
+        b.add_column(
+            sa.Column(
+                "invited", sa.Boolean(), server_default=sa.text("false"), nullable=False
+            ),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("users") as b:
+        b.drop_column("invited")
+        b.drop_column("invite_confirmed")

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,3 +1,5 @@
+> You can automatically invite players to the game by @ mentioning them in the command. They will be sent invite confirmations and the game won't be posted to the channel until they've responded.
+> 
 > Players will be able to join or leave the game by reacting to the message that SpellBot sends with the ➕ and ➖ emoji.
 > 
 > Up to five tags can be given as well to help describe the game expereince that you want. For example you might send `!lfg no-combo proxy` which will assign the tags: `no-combo` and `proxy` to your game. People will be able to see what tags are set on your game when they are looking for games to join.


### PR DESCRIPTION
**Description**

Allows users to invite other players to their game when they use the `!lfg` command by `@` mentioning them in the command.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [x] Entire test suite passes
