### PR TITLE
Implements msg: and tags: options

### DIFF
--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -139,21 +139,23 @@ class Game(Base):
         )
 
     def __repr__(self):
-        return json.dumps(
-            {
-                "id": self.id,
-                "created_at": str(self.created_at),
-                "updated_at": str(self.updated_at),
-                "expires_at": str(self.expires_at),
-                "size": self.size,
-                "guild_xid": self.guild_xid,
-                "channel_xid": self.channel_xid,
-                "url": self.url,
-                "status": self.status,
-                "message": self.message,
-                "message_xid": self.message_xid,
-            }
-        )
+        return json.dumps(self.to_json())
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "created_at": str(self.created_at),
+            "updated_at": str(self.updated_at),
+            "expires_at": str(self.expires_at),
+            "size": self.size,
+            "guild_xid": self.guild_xid,
+            "channel_xid": self.channel_xid,
+            "url": self.url,
+            "status": self.status,
+            "message": self.message,
+            "message_xid": self.message_xid,
+            "tags": [tag.name for tag in self.tags],
+        }
 
     def to_embed(self):
         if self.url:

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -5,21 +5,23 @@
 `!begin <event id>`
 >  Confirm creation of games for the given event id. _Requires the "SpellBot Admin" role._
 
-`!event <column 1> <column 2> ... <column 3> [-- An optional message to add.]`
+`!event <column 1> <column 2> ... [tags: tag-1 tag-2] [msg: Hello world!]`
 >  Create many games in batch from an attached CSV data file. _Requires the "SpellBot Admin" role._
 > 
 > For example, if your event is for a Modern tournement you might attach a CSV file with a comment like `!event Player1Username Player2Username`. This would assume that the players' discord user names are found in the "Player1Username" and "Player2Username" CSV columns. The game size is deduced from the number of column names given, so we know the games created in this example are `size:2`.
 > 
 > Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
-> * Optional: Add a message by using " -- " followed by the message content.
+> * Optional: Add a message by using "msg: " followed by the message content.
+> * Optional: Add tags by using "tags: " followed by the tags you want.
 
-`!game [similar parameters as !lfg] [-- An optional additional message to send.]`
+`!game @player1 @player2 ... [tags: tag-1 tag-2] [msg: Hello world!]`
 >  Create a game between mentioned users. _Requires the "SpellBot Admin" role._
 > 
-> Operates similarly to the `!lfg` command with a few key deferences. First, see that command's usage help for more details. Then, here are the differences:
+> Allows event runners to spin up an ad-hoc game directly between mentioned players.
 > * The user who issues this command is **NOT** added to the game themselves.
 > * You must mention all of the players to be seated in the game.
-> * Optional: Add a message by using " -- " followed by the message content.
+> * Optional: Add a message by using "msg: " followed by the message content.
+> * Optional: Add tags by using "tags: " followed by the tags you want.
 
 `!help`
 >  Sends you this help message.


### PR DESCRIPTION
**Description**

Changes how the `-- optional message` construct works for the admin commands `!event` and `!game`. Instead, we now support:

- `msg: this is an optional message`
- `tags: these are tags`

In both the `!event` and `!game` commands.

- Resolves https://github.com/lexicalunit/spellbot/issues/63

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
