### PR TITLE
Adds a new play command, similar to the old

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ being too spammy in text channels.**
 For players just looking to start some games, these commands are for you!
 
 - `!lfg`: Create a pending game for people join.
+- `!play`: Same as `!lfg`, but look for an existing game to join first.
 - `!leave`: Leave any pending games that you've signed up for.
 
 When you run the `!lfg` command, SpellBot will post a message for sign ups.

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -40,14 +40,11 @@ invite_denied: Thank you for your response.
 invite_not_invited: Sorry, you do not currently have any pending invitations.
 leave: You've been removed from the pending game that you were signed up for.
 leave_already: You we're not in any pending games.
-lfg_already: You're already in a pending game. If you want to, you can leave all games
-  with `${prefix}leave`.
 lfg_invited: You've been invtied to a game by $mention. To confirm or deny please
   respond with yes or no.
 lfg_mention_already: Sorry, but $mention is already in another pending game and can't
   be invited.
-lfg_size_bad: Sorry, game size should be between 2 and 4.
-lfg_too_many_mentions: Sorry, you've mentioned too many players for this size game.
+lfg_too_many_mentions: Sorry, you've mentioned too many players for that size game.
 no_dm: That command only works in text channels.
 not_a_command: Sorry, there is no "$request" command.
 not_admin: You do not have admin permissions for this bot.
@@ -63,3 +60,5 @@ spellbot_prefix: This bot will now use "$prefix" as its command prefix for this 
 spellbot_prefix_none: Please provide a prefix string.
 spellbot_unknown_subcommand: The subcommand "$command" is not recognized.
 tags_too_many: Sorry, you can not use more than 5 tags.
+user_waiting: You're already waiting for a game. If you want to, you can leave that
+  game with `${prefix}leave` and then try again.

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -32,5 +32,5 @@
 `!leave`
 >  Leave any pending game that you've signed up for on this server.
 
-`!lfg [size:N] [~tag-1] [~tag-2] [...] [~tag-N]`
+`!lfg [size:N] [@player-1] [@player-2] ... [~tag-1] [~tag-2] ...`
 >  Create a pending game for players to join.

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -4,7 +4,12 @@
 > 
 > Players will be able to join or leave the game by reacting to the message that SpellBot sends with the ➕ and ➖ emoji.
 > 
-> Up to five tags can be given as well to help describe the game expereince that you want. For example you might send `!lfg ~no-combo ~proxy` which will assign the tags: `no-combo` and `proxy` to your game. People will be able to see what tags are set on your game when they are looking for games to join.
+> Up to five tags can be given as well to help describe the game expereince that you want. For example you might send `!lfg ~no-combo ~proxy` which will assign the tags `no-combo` and `proxy` to your game. People will be able to see what tags are set on your game when they are looking for games to join.
+
+`!play`
+>  Quickly join a game now or else create a new looking-for-game post.
+> 
+> This command works exactly like the !lfg command except that it will first try to add you to an existing pending game if one exists. Useful if you just want to play a game of Magic and don't want to go find one and manually add your emoji reaction to it manually.
 
 `!spellbot <subcommand> [subcommand parameters]`
 >  Configure SpellBot for your server. _Requires the "SpellBot Admin" role._


### PR DESCRIPTION
**Description**

Re-introduces the `!play` command which works similarly to the old command. The new command does NOT use hidden play queues and matchmaking logic. Instead it does the same thing as `!lfg` **except** that it will first look for an existing pending games to join before creating a new pending game.

So... it's the lazy player's version of `!lfg`, basically.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [x] Entire test suite passes
