### PR TITLE
Adds error checking for duplicate users in csv file

### DIFF
--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -11,6 +11,9 @@ event_bad_play_count: Sorry $reply, but the player count must be between 2 and 4
 event_created: Ok $reply, I've created event $event_id! This event will have $count
   games. If everything looks good, next run `${prefix}begin $event_id` to start the
   event.
+event_duplicate_user: '**Error:** The user $name appears in more than one paring in
+  this event file! I first noticed this duplicate on row $row which contains the players:
+  $players. Please resolve this issue and try again.'
 event_empty: Hey $reply, no games were created for this event. Please address any
   warnings and try again.
 event_missing_player: '**Warning:** Event file is missing a player name on row $row.

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -1261,6 +1261,26 @@ class TestSpellBot:
             f"Sorry <@{author.id}>, but you can not use more than 5 tags."
         )
 
+    async def test_on_message_event_duplicate_user(self, client, channel_maker):
+        channel = channel_maker.text()
+        author = an_admin()
+        data = bytes(
+            "player1,player2\n"
+            f"{AMY.name}#1234,@{JR.name}\n"
+            f"{ADAM.name},{AMY.name}\n",
+            "utf-8",
+        )
+        csv_file = MockAttachment("event.csv", data)
+        comment = "!event player1 player2"
+        message = MockMessage(author, channel, comment, attachments=[csv_file])
+        await client.on_message(message)
+        assert channel.last_sent_response == (
+            f"**Error:** The user {AMY.name} appears in more than one paring in this"
+            " event file! I first noticed this duplicate on row 2 which contains the"
+            f' players: "{ADAM.name}", "{AMY.name}". Please resolve this issue and try'
+            " again."
+        )
+
     async def test_on_message_event(self, client, channel_maker):
         channel = channel_maker.text()
         author = an_admin()


### PR DESCRIPTION
**Description**

I noticed that if a user appears in the event csv file multiple times, things will get weird. A user can only be assigned to a single event at a time so they would get re-assigned to the last pairing in which they were placed. That would leave any previous pairing broken.

This PR adds code to check for this error and report it back to the admin when it happens.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
