### PR TITLE
Improves the way the spellbot channels command works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Don't allow admins to lock themselves out of using SpellBot but setting invalid channels.
+- Allow admins to set the bot to operate within all channels.
+- Better communication about warnings and errors when using the `!spellbot channels` command.
+
 ## [v3.13.3](https://github.com/lexicalunit/spellbot/releases/tag/v3.13.3) - 2020-07-28
 
 - Adds #BLM donation link to front page.

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -61,9 +61,12 @@ not_admin: $reply, you do not have admin permissions to run that command.
 play_found: I found a game for you, $reply. You have been signed up for it!
 react_already_in: Sorry $reply, I couldn't add you to that game because you're already
   signed up for another game. You can use `${prefix}leave` to leave that game.
-spellbot_channels: 'Ok $reply, I will now only respond in: $channels'
+spellbot_channels: 'Ok $reply, I will now operate within: $channels'
 spellbot_channels_none: 'Sorry $reply, but please provide a list of channels. Like
   #bot-commands, for example.'
+spellbot_channels_warn: 'Sorry $reply, but "$param" is not a valid channel. Try using
+  # to mention the channels you want or using "all" if you want me to operate in all
+  channels.'
 spellbot_expire: Ok $reply, game expiration time on this server has been set to $expire
   minutes.
 spellbot_expire_bad: Sorry $reply, but game expiration time should be between 10 and


### PR DESCRIPTION
**Description**

- Resolves #104 
- Don't allow admins to lock themselves out of using SpellBot but setting invalid channels.
- Allow admins to set the bot to operate within all channels.
- Better communication about warnings and errors when using the `!spellbot channels` command.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
