### PR TITLE
Add note about running spellbot in dev mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Make sure that you have [set up your environmental variables](/README.md#-runnin
 poetry run spellbot --help
 ```
 
-This will list some useful flags you can provide to run spellbot. To get started developing, run:
+This will list some useful flags you can provide to run SpellBot. To get started developing, run:
 
 ```
 poetry run spellbot --dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,14 @@ Make sure that you have [set up your environmental variables](/README.md#-runnin
 poetry run spellbot --help
 ```
 
+This will list some useful flags you can provide to run spellbot. To get started developing, run:
+
+```
+poetry run spellbot --dev
+```
+
+This will start SpellBot and reload it whenever the source code changes.
+
 ## Running tests
 
 We use [tox](https://tox.readthedocs.io/en/latest/) to manage test execution.


### PR DESCRIPTION
**Description**

Adds a short note recommending using the `--dev` flag when contributing to SpellBot's development.

Might not be needed since `--help` lists it as an option, but figured it'd be good to call out the main flag you'd run for development.

**Checklist**

- [ ] ~~Add tests for these changes~~
- [x] Test coverage is not decreased
- [x] Entire test suite passes
