### PR TITLE
Automatically leave games when trying to join a new game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated dunamai dependency to 1.3.0.
 - Changed twitter social link to the new @SpellBotIO twitter account.
 - Updated isort dev dependency to 5.2.2.
+- When trying to `!lfg` and you're already in a pending game, you will now automatically be
+  removed from that game first, then your command will be processed as normal.
+- When trying to react with a + to a game when you're already in a pending game, you will
+  first be removed from your pending game and then added to that new game.
 
 ## [v3.14.0](https://github.com/lexicalunit/spellbot/releases/tag/v3.14.0) - 2020-07-30
 

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -64,8 +64,6 @@ no_dm: Hello $reply! That command only works in text channels.
 not_a_command: Sorry $reply, there is no "$request" command.
 not_admin: $reply, you do not have admin permissions to run that command.
 play_found: I found a game for you, $reply. You have been signed up for it!
-react_already_in: Sorry $reply, I couldn't add you to that game because you're already
-  signed up for another game. You can use `${prefix}leave` to leave that game.
 spellbot_channels: 'Ok $reply, I will now operate within: $channels'
 spellbot_channels_none: 'Sorry $reply, but please provide a list of channels. Like
   #bot-commands, for example.'
@@ -84,5 +82,3 @@ spellbot_prefix: Ok $reply, I will now use "$prefix" as my command prefix on thi
 spellbot_prefix_none: Sorry $reply, but please provide a prefix string.
 spellbot_unknown_subcommand: Sorry $reply, but the subcommand "$command" is not recognized.
 tags_too_many: Sorry $reply, but you can not use more than 5 tags.
-user_waiting: Hi $reply! You're already waiting in a game. If you want to, you can
-  leave that game with `${prefix}leave` and then try again.

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -1675,8 +1675,7 @@ class TestSpellBot:
         await client.on_message(MockMessage(author, channel, "!lfg"))
         await client.on_message(MockMessage(author, channel, "!lfg"))
         assert channel.last_sent_response == (
-            f"Hi <@{author.id}>! You're already waiting in a game."
-            " If you want to, you can leave that game with `!leave` and then try again."
+            f"I found a game for you, <@{author.id}>. You have been signed up for it!"
         )
 
     async def test_on_message_lfg(self, client, channel_maker):
@@ -2027,11 +2026,8 @@ class TestSpellBot:
             member=ADAM,
         )
         await client.on_raw_reaction_add(payload)
-        assert ADAM.last_sent_response == (
-            f"Sorry <@{ADAM.id}>, I couldn't add you to that game"
-            " because you're already signed up for another game."
-            " You can use `!leave` to leave that game."
-        )
+        assert len(all_games(client)) == 2
+        assert game_embed_for(client, ADAM, False) != game_embed_for(client, GUY, False)
 
         # TODO: Actually test that the embed was edited correctly.
 


### PR DESCRIPTION
**Description**

- When trying to `!lfg` and you're already in a pending game, you will now automatically be
  removed from that game first, then your command will be processed as normal.
- When trying to react with a + to a game when you're already in a pending games, you will
  first be removed from your pending game and then added to that new game.

- Resolves https://github.com/lexicalunit/spellbot/issues/127

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [ ] Entire test suite passes
