### PR TITLE
Provide game post link for convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for google analytics tag manager.
 - Adds some notes about the `SpellBot Admin` role and links to Discord
   documentation on role creation to both the readme (thanks to @crookedneighbor) and front page.
+- Added message links when informing the player that they were added to a game so it's easier to
+  find the post. Before you would have had to scroll up in history to find it manually.
 
 ### Changed
 

--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -167,6 +167,10 @@ def parse_opts(params: List[str]) -> dict:
     }
 
 
+def post_link(server_xid: int, channel_xid: int, message_xid: int,) -> str:
+    return f"https://discordapp.com/channels/{server_xid}/{channel_xid}/{message_xid}"
+
+
 def is_admin(
     channel: TextChannel, user_or_member: Union[discord.User, discord.Member]
 ) -> bool:
@@ -1060,7 +1064,13 @@ class SpellBot(discord.Client):
             if post:
                 if not use_queue:
                     await message.channel.send(
-                        s("play_found", reply=f"<@{mentionor_xid}>")
+                        s(
+                            "play_found",
+                            reply=f"<@{mentionor_xid}>",
+                            link=post_link(
+                                server.guild_xid, message.channel.id, game.message_xid
+                            ),
+                        )
                     )
                 found_discord_users = []
                 if len(cast(List[User], game.users)) == game.size:

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -63,7 +63,8 @@ lfg_too_many_mentions: Sorry $reply, but you've mentioned too many players for t
 no_dm: Hello $reply! That command only works in text channels.
 not_a_command: Sorry $reply, there is no "$request" command.
 not_admin: $reply, you do not have admin permissions to run that command.
-play_found: I found a game for you, $reply. You have been signed up for it!
+play_found: 'I found a game for you, $reply. You have been signed up for it! Go to
+  game post: $link'
 spellbot_channels: 'Ok $reply, I will now operate within: $channels'
 spellbot_channels_none: 'Sorry $reply, but please provide a list of channels. Like
   #bot-commands, for example.'

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -1673,9 +1673,12 @@ class TestSpellBot:
         channel = channel_maker.text()
         author = someone()
         await client.on_message(MockMessage(author, channel, "!lfg"))
+        post = channel.last_sent_message
         await client.on_message(MockMessage(author, channel, "!lfg"))
         assert channel.last_sent_response == (
             f"I found a game for you, <@{author.id}>. You have been signed up for it!"
+            " Go to game post: https://discordapp.com/channels/"
+            f"{channel.guild.id}/{channel.id}/{post.id}"
         )
 
     async def test_on_message_lfg(self, client, channel_maker):


### PR DESCRIPTION
**Description**

- Added message links when informing the player that they were added to a game so it's easier to
  find the post. Before you would have had to scroll up in history to find it manually.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [ ] Entire test suite passes
