### PR TITLE
Do not DM when prompting for help

### DIFF
--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -865,9 +865,6 @@ class SpellBot(discord.Client):
             "💜 You can help keep SpellBot running by supporting me on Ko-fi! "
             "<https://ko-fi.com/Y8Y51VTHZ>"
         )
-        await message.channel.send(
-            s("dm_sent", reply=f"<@{cast(discord.User, message.author).id}>")
-        )
         for page in paginate(usage):
             await message.author.send(page)
 

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -6,7 +6,6 @@ begin_user_left: '**Warning:** A user left the server since this event was creat
   SpellBot did **NOT** start the game for the players: $players.'
 did_you_mean: 'Sorry $reply, that''s not a command. Did you mean to use one of these
   commands: $possible?'
-dm_sent: Right on $reply, I'll send you a Direct Message with details.
 event_bad_play_count: Sorry $reply, but the player count must be between 2 and 4.
 event_created: Ok $reply, I've created event $event_id! This event will have $count
   games. If everything looks good, next run `${prefix}begin $event_id` to start the

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -2418,7 +2418,7 @@ class TestSpellBot:
         author = not_an_admin()
         channel = channel_maker.text()
         await client.on_message(MockMessage(author, channel, "!spellbot help"))
-        assert len(channel.all_sent_calls) == 1
+        assert len(channel.all_sent_calls) == 0
         assert len(author.all_sent_calls) >= 1
 
     async def test_on_message_queue_no_mentions(self, client, channel_maker):


### PR DESCRIPTION
**Description**

Removes response that a DM is sent.

- Resolves #121

IMO, the bot should acknowledge in some way in the channel, maybe via an emoji reaction? Just to let anyone else (other than the author of course) who sees the `!help` message know that something did happen.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
