### PR TITLE
Pull mock users into separate file

### DIFF
--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import spellbot
+
+##############################
+# Test Suite Constants
+##############################
+
+CLIENT_TOKEN = "my-token"
+CLIENT_AUTH = "my-auth"
+
+TST_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_ROOT = TST_ROOT / "fixtures"
+REPO_ROOT = TST_ROOT.parent
+SRC_ROOT = REPO_ROOT / "src"
+
+SRC_DIRS = [REPO_ROOT / "tests", SRC_ROOT / "spellbot", REPO_ROOT / "scripts"]
+
+S_SPY = Mock(wraps=spellbot.s)

--- a/tests/mocks/users.py
+++ b/tests/mocks/users.py
@@ -1,0 +1,27 @@
+from mocks.discord import MockMember, MockRole  # type: ignore
+
+CLIENT_USER = "ADMIN"
+CLIENT_USER_ID = 82226367030108160
+
+ADMIN_ROLE = MockRole("SpellBot Admin")
+PLAYER_ROLE = MockRole("Player Player")
+
+ADMIN = MockMember(CLIENT_USER, CLIENT_USER_ID, roles=[ADMIN_ROLE], admin=True)
+FRIEND = MockMember("friend", 82169952898900001, roles=[PLAYER_ROLE])
+BUDDY = MockMember("buddy", 82942320688700002, roles=[ADMIN_ROLE, PLAYER_ROLE])
+GUY = MockMember("guy", 82988021019800003)
+DUDE = MockMember("dude", 82988761019800004, roles=[ADMIN_ROLE])
+
+JR = MockMember("J.R.", 72988021019800005)
+ADAM = MockMember("Adam", 62988021019800006)
+TOM = MockMember("Tom", 62988021019800016)
+AMY = MockMember("Amy", 52988021019800007)
+JACOB = MockMember("Jacob", 42988021019800008)
+
+PUNK = MockMember("punk", 119678027792600009)  # for a memeber that's not in our channel
+BOT = MockMember("robot", 82169567890900010)
+BOT.bot = True
+ADMIN.bot = True
+
+SERVER_MEMBERS = [FRIEND, BUDDY, GUY, DUDE, ADMIN, JR, ADAM, TOM, AMY, JACOB]
+ALL_USERS = []  # users that are on the server, setup in client fixture

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -6,12 +6,20 @@ from datetime import datetime, timedelta
 from os import chdir
 from pathlib import Path
 from subprocess import run
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 from warnings import warn
 
 import pytest
 import pytz
 import toml
+from helpers.constants import (  # type:ignore
+    CLIENT_AUTH,
+    CLIENT_TOKEN,
+    FIXTURES_ROOT,
+    REPO_ROOT,
+    S_SPY,
+    SRC_DIRS,
+)
 from mocks.discord import (  # type: ignore
     AsyncMock,
     MockAttachment,
@@ -67,22 +75,6 @@ class MockDiscordClient:
     async def fetch_channel(self, channel_id):
         return self.get_channel(channel_id)
 
-
-##############################
-# Test Suite Constants
-##############################
-
-CLIENT_TOKEN = "my-token"
-CLIENT_AUTH = "my-auth"
-
-TST_ROOT = Path(__file__).resolve().parent
-FIXTURES_ROOT = TST_ROOT / "fixtures"
-REPO_ROOT = TST_ROOT.parent
-SRC_ROOT = REPO_ROOT / "src"
-
-SRC_DIRS = [REPO_ROOT / "tests", SRC_ROOT / "spellbot", REPO_ROOT / "scripts"]
-
-S_SPY = Mock(wraps=spellbot.s)
 
 ##############################
 # Test Suite Utilities

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -17,11 +17,26 @@ from mocks.discord import (  # type: ignore
     MockAttachment,
     MockChannel,
     MockDM,
-    MockMember,
     MockMessage,
     MockPayload,
-    MockRole,
     MockTextChannel,
+)
+from mocks.users import (  # type: ignore
+    ADAM,
+    ADMIN,
+    ADMIN_ROLE,
+    ALL_USERS,
+    AMY,
+    BOT,
+    BUDDY,
+    DUDE,
+    FRIEND,
+    GUY,
+    JACOB,
+    JR,
+    PUNK,
+    SERVER_MEMBERS,
+    TOM,
 )
 
 import spellbot
@@ -59,8 +74,6 @@ class MockDiscordClient:
 
 CLIENT_TOKEN = "my-token"
 CLIENT_AUTH = "my-auth"
-CLIENT_USER = "ADMIN"
-CLIENT_USER_ID = 82226367030108160
 
 TST_ROOT = Path(__file__).resolve().parent
 FIXTURES_ROOT = TST_ROOT / "fixtures"
@@ -68,29 +81,6 @@ REPO_ROOT = TST_ROOT.parent
 SRC_ROOT = REPO_ROOT / "src"
 
 SRC_DIRS = [REPO_ROOT / "tests", SRC_ROOT / "spellbot", REPO_ROOT / "scripts"]
-
-ADMIN_ROLE = MockRole("SpellBot Admin")
-PLAYER_ROLE = MockRole("Player Player")
-
-ADMIN = MockMember(CLIENT_USER, CLIENT_USER_ID, roles=[ADMIN_ROLE], admin=True)
-FRIEND = MockMember("friend", 82169952898900001, roles=[PLAYER_ROLE])
-BUDDY = MockMember("buddy", 82942320688700002, roles=[ADMIN_ROLE, PLAYER_ROLE])
-GUY = MockMember("guy", 82988021019800003)
-DUDE = MockMember("dude", 82988761019800004, roles=[ADMIN_ROLE])
-
-JR = MockMember("J.R.", 72988021019800005)
-ADAM = MockMember("Adam", 62988021019800006)
-TOM = MockMember("Tom", 62988021019800016)
-AMY = MockMember("Amy", 52988021019800007)
-JACOB = MockMember("Jacob", 42988021019800008)
-
-PUNK = MockMember("punk", 119678027792600009)  # for a memeber that's not in our channel
-BOT = MockMember("robot", 82169567890900010)
-BOT.bot = True
-ADMIN.bot = True
-
-SERVER_MEMBERS = [FRIEND, BUDDY, GUY, DUDE, ADMIN, JR, ADAM, TOM, AMY, JACOB]
-ALL_USERS = []  # users that are on the server, setup in client fixture
 
 S_SPY = Mock(wraps=spellbot.s)
 


### PR DESCRIPTION
**Description**

Similar to the discord mocks refactor, simply moves the mock users into their own file.

**Checklist**

- [ ] ~~Add tests for these changes~~
- [x] Test coverage is not decreased
- [x] Entire test suite passes
