### PR TITLE
Send message when spellbot does not have permission to manage reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Adds meta theme-color and meta og:site_name to front page.
 - Adds a note about Administrator permissions to the Commands for Admins section of the front page.
-- Spellbot will message in the channel when they do not have permission to adjust reactions
+- Spellbot will message in the channel when it does not have permission to adjust reactions.
 
 ## [v3.15.4](https://github.com/lexicalunit/spellbot/releases/tag/v3.15.4) - 2020-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Adds meta theme-color and meta og:site_name to front page.
 - Adds a note about Administrator permissions to the Commands for Admins section of the front page.
+- Spellbot will message in the channel when they do not have permission to adjust reactions
 
 ## [v3.15.4](https://github.com/lexicalunit/spellbot/releases/tag/v3.15.4) - 2020-08-02
 

--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -299,7 +299,7 @@ class SpellBot(discord.Client):
         try:
             yield session
         except exc.SQLAlchemyError as e:
-            logger.exception("database error:", e)
+            logger.exception("database error: %s", e)
             session.rollback()
             raise
         finally:
@@ -319,7 +319,7 @@ class SpellBot(discord.Client):
             discord.errors.NotFound,
             discord.errors.Forbidden,
         ) as e:
-            logger.exception("warning: discord: could not fetch message", e)
+            logger.exception("warning: discord: could not fetch message: %s", e)
             return None
 
     async def safe_fetch_channel(
@@ -336,7 +336,7 @@ class SpellBot(discord.Client):
             discord.errors.NotFound,
             discord.errors.Forbidden,
         ) as e:
-            logger.exception("warning: discord: could not fetch channel", e)
+            logger.exception("warning: discord: could not fetch channel: %s", e)
             return None
 
     async def safe_fetch_user(
@@ -348,7 +348,7 @@ class SpellBot(discord.Client):
         try:
             return await self.fetch_user(user_xid)
         except (discord.errors.NotFound, discord.errors.HTTPException) as e:
-            logger.exception("warning: discord: could fetch user", e)
+            logger.exception("warning: discord: could fetch user: %s", e)
             return None
 
     async def safe_edit_message(
@@ -361,7 +361,7 @@ class SpellBot(discord.Client):
             discord.errors.Forbidden,
             discord.errors.HTTPException,
         ) as e:
-            logger.exception("warning: discord: could not edit message", e)
+            logger.exception("warning: discord: could not edit message: %s", e)
 
     async def safe_delete_message(
         self, message: discord.Message
@@ -373,7 +373,7 @@ class SpellBot(discord.Client):
             discord.errors.NotFound,
             discord.errors.HTTPException,
         ) as e:
-            logger.exception("warning: discord: could not delete message", e)
+            logger.exception("warning: discord: could not delete message: %s", e)
 
     def _begin_background_tasks(
         self, loop: asyncio.AbstractEventLoop

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -66,6 +66,8 @@ not_a_command: Sorry $reply, there is no "$request" command.
 not_admin: $reply, you do not have admin permissions to run that command.
 play_found: 'I found a game for you, $reply. You have been signed up for it! Go to
   game post: $link'
+reaction_permissions_required: I do not have permission to adjust reactions. A server
+  admin will need to adjust my permissions.
 spellbot_channels: 'Ok $reply, I will now operate within: $channels'
 spellbot_channels_none: 'Sorry $reply, but please provide a list of channels. Like
   #bot-commands, for example.'

--- a/src/spellbot/reactions.py
+++ b/src/spellbot/reactions.py
@@ -1,0 +1,26 @@
+import logging
+
+import discord
+
+logger = logging.getLogger(__name__)
+
+
+async def safe_remove_reaction(
+    message: discord.Message, emoji: str, user: discord.User
+) -> None:  # pragma: no cover
+    try:
+        await message.remove_reaction(emoji, user)
+    except (
+        discord.errors.HTTPException,
+        discord.errors.Forbidden,
+        discord.errors.NotFound,
+        discord.errors.InvalidArgument,
+    ) as e:
+        logger.exception("warning: discord: could not remove reaction", e)
+
+
+async def safe_clear_reactions(message: discord.Message) -> None:  # pragma: no cover
+    try:
+        await message.clear_reactions()
+    except (discord.errors.HTTPException, discord.errors.Forbidden) as e:
+        logger.exception("warning: discord: could not clear reactions", e)

--- a/src/spellbot/reactions.py
+++ b/src/spellbot/reactions.py
@@ -2,6 +2,8 @@ import logging
 
 import discord
 
+from spellbot.assets import s
+
 logger = logging.getLogger(__name__)
 
 
@@ -10,9 +12,10 @@ async def safe_remove_reaction(
 ) -> None:  # pragma: no cover
     try:
         await message.remove_reaction(emoji, user)
+    except discord.errors.Forbidden:
+        await message.channel.send(s("reaction_permissions_required"))
     except (
         discord.errors.HTTPException,
-        discord.errors.Forbidden,
         discord.errors.NotFound,
         discord.errors.InvalidArgument,
     ) as e:
@@ -22,5 +25,7 @@ async def safe_remove_reaction(
 async def safe_clear_reactions(message: discord.Message) -> None:  # pragma: no cover
     try:
         await message.clear_reactions()
-    except (discord.errors.HTTPException, discord.errors.Forbidden) as e:
+    except discord.errors.Forbidden:
+        await message.channel.send(s("reaction_permissions_required"))
+    except discord.errors.HTTPException as e:
         logger.exception("warning: discord: could not clear reactions", e)

--- a/src/spellbot/reactions.py
+++ b/src/spellbot/reactions.py
@@ -19,7 +19,7 @@ async def safe_remove_reaction(
         discord.errors.NotFound,
         discord.errors.InvalidArgument,
     ) as e:
-        logger.exception("warning: discord: could not remove reaction", e)
+        logger.exception("warning: discord: could not remove reaction: %s", e)
 
 
 async def safe_clear_reactions(message: discord.Message) -> None:
@@ -28,4 +28,4 @@ async def safe_clear_reactions(message: discord.Message) -> None:
     except discord.errors.Forbidden:
         await message.channel.send(s("reaction_permissions_required"))
     except discord.errors.HTTPException as e:
-        logger.exception("warning: discord: could not clear reactions", e)
+        logger.exception("warning: discord: could not clear reactions: %s", e)

--- a/src/spellbot/reactions.py
+++ b/src/spellbot/reactions.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 async def safe_remove_reaction(
     message: discord.Message, emoji: str, user: discord.User
-) -> None:  # pragma: no cover
+) -> None:
     try:
         await message.remove_reaction(emoji, user)
     except discord.errors.Forbidden:
@@ -22,7 +22,7 @@ async def safe_remove_reaction(
         logger.exception("warning: discord: could not remove reaction", e)
 
 
-async def safe_clear_reactions(message: discord.Message) -> None:  # pragma: no cover
+async def safe_clear_reactions(message: discord.Message) -> None:
     try:
         await message.clear_reactions()
     except discord.errors.Forbidden:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,13 @@ from .mocks.client import channel_maker, client, patch_discord  # type: ignore
 # Ensure that TestMeta runs last as those tests require the entire test suite
 # to have finished before they can can start. The other test suites could
 # theoretically be run in any order, but this is the order that I prefer.
-SUITE_ORDER = ["TestSpellBot", "TestMigrations", "TestCodebase", "TestMeta"]
+SUITE_ORDER = [
+    "TestSpellBot",
+    "TestReactions",
+    "TestMigrations",
+    "TestCodebase",
+    "TestMeta",
+]
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/tests/mocks/client.py
+++ b/tests/mocks/client.py
@@ -55,6 +55,7 @@ def client(monkeypatch, mocker, patch_discord, tmp_path):
 
     # Keep track of strings used in the test suite.
     monkeypatch.setattr(spellbot, "s", S_SPY)
+    monkeypatch.setattr(spellbot.reactions, "s", S_SPY)
 
     # Don't actually begin background tasks during tests.
     monkeypatch.setattr(spellbot.SpellBot, "_begin_background_tasks", MagicMock())

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -25,6 +25,7 @@ class MockDiscordMessage:
     def __init__(self):
         global MOCK_DISCORD_MESSAGE_ID_START
         self.id = MOCK_DISCORD_MESSAGE_ID_START
+        self.channel = MockChannel("id", "text")
         MOCK_DISCORD_MESSAGE_ID_START += 1
         self.reactions = []
 

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -11,9 +11,7 @@ from .mocks.users import FRIEND  # type: ignore
 
 @pytest.mark.asyncio
 class TestReactions:
-    async def test_safe_remove_reaction_removes_reaction_from_message(
-        self, channel_maker
-    ):
+    async def test_safe_remove_reaction_removes_reaction_from_message(self):
         message = MockDiscordMessage()
         with patch.object(
             message, "remove_reaction", wraps=message.remove_reaction
@@ -23,7 +21,7 @@ class TestReactions:
             fake_message.assert_called_with("emoji", FRIEND)
 
     async def test_safe_remove_reaction_sends_message_when_forbidden_exception_is_thrown(
-        self, channel_maker
+        self,
     ):
         message = MockDiscordMessage()
         with patch.object(
@@ -46,7 +44,7 @@ class TestReactions:
                     )
                 )
 
-    async def test_clear_reactions_clears_reactions_from_message(self, channel_maker):
+    async def test_clear_reactions_clears_reactions_from_message(self):
         message = MockDiscordMessage()
         with patch.object(
             message, "clear_reactions", wraps=message.clear_reactions
@@ -56,7 +54,7 @@ class TestReactions:
             fake_message.assert_called()
 
     async def test_clear_reactions_sends_message_when_forbidden_exception_is_thrown(
-        self, channel_maker
+        self, client
     ):
         message = MockDiscordMessage()
         with patch.object(

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import pytest
+
+from spellbot.reactions import safe_clear_reactions, safe_remove_reaction
+
+from .mocks.discord import MockDiscordMessage  # type: ignore
+from .mocks.users import FRIEND  # type: ignore
+
+
+@pytest.mark.asyncio
+class TestReactions:
+    async def test_safe_remove_reaction_removes_reaction_from_message(
+        self, channel_maker
+    ):
+        message = MockDiscordMessage()
+        with patch.object(
+            message, "remove_reaction", wraps=message.remove_reaction
+        ) as monkey:
+            await safe_remove_reaction(message, "emoji", FRIEND)
+
+            monkey.assert_called_with("emoji", FRIEND)
+
+    async def test_clear_reactions_clears_reactions_from_message(self, channel_maker):
+        message = MockDiscordMessage()
+        with patch.object(
+            message, "clear_reactions", wraps=message.clear_reactions
+        ) as monkey:
+            await safe_clear_reactions(message)
+
+            monkey.assert_called()

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import Mock, patch
 
 import discord
@@ -16,7 +17,9 @@ class TestReactions:
         with patch.object(
             message, "remove_reaction", wraps=message.remove_reaction
         ) as fake_message:
-            await safe_remove_reaction(message, "emoji", FRIEND)
+            await safe_remove_reaction(
+                cast(discord.Message, message), "emoji", cast(discord.User, FRIEND)
+            )
 
             fake_message.assert_called_with("emoji", FRIEND)
 
@@ -35,21 +38,35 @@ class TestReactions:
             with patch.object(
                 message.channel, "send", wraps=message.channel.send
             ) as fake_channel_send:
-                await safe_remove_reaction(message, "emoji", FRIEND)
+                await safe_remove_reaction(
+                    cast(discord.Message, message), "emoji", cast(discord.User, FRIEND)
+                )
 
                 fake_channel_send.assert_called_with(
-                    (
-                        "I do not have permission to adjust "
-                        "reactions. A server admin will need to adjust my permissions."
-                    )
+                    "I do not have permission to adjust "
+                    "reactions. A server admin will need to adjust my permissions."
                 )
+
+    async def test_remove_reaction_when_http_error_is_thrown(self, caplog):
+        message = MockDiscordMessage()
+        response = Mock()
+        response.status = 403
+        with patch.object(message, "remove_reaction", wraps=message.remove_reaction) as m:
+            m.side_effect = discord.errors.HTTPException(response, "BAD REQUEST")
+            with patch.object(message.channel, "send", wraps=message.channel.send):
+                await safe_remove_reaction(
+                    cast(discord.Message, message), "emoji", cast(discord.User, FRIEND)
+                )
+
+                assert "warning: discord: could not remove reaction" in caplog.text
+                assert "BAD REQUEST" in caplog.text
 
     async def test_clear_reactions_clears_reactions_from_message(self):
         message = MockDiscordMessage()
         with patch.object(
             message, "clear_reactions", wraps=message.clear_reactions
         ) as fake_message:
-            await safe_clear_reactions(message)
+            await safe_clear_reactions(cast(discord.Message, message))
 
             fake_message.assert_called()
 
@@ -68,11 +85,21 @@ class TestReactions:
             with patch.object(
                 message.channel, "send", wraps=message.channel.send
             ) as fake_channel_send:
-                await safe_clear_reactions(message)
+                await safe_clear_reactions(cast(discord.Message, message))
 
                 fake_channel_send.assert_called_with(
-                    (
-                        "I do not have permission to adjust "
-                        "reactions. A server admin will need to adjust my permissions."
-                    )
+                    "I do not have permission to adjust "
+                    "reactions. A server admin will need to adjust my permissions."
                 )
+
+    async def test_clear_reactions_when_http_error_is_thrown(self, caplog):
+        message = MockDiscordMessage()
+        fake_response = Mock()
+        fake_response.status = 400
+        with patch.object(message, "clear_reactions", wraps=message.clear_reactions) as m:
+            m.side_effect = discord.errors.HTTPException(fake_response, "BAD REQUEST")
+            with patch.object(message.channel, "send", wraps=message.channel.send):
+                await safe_clear_reactions(cast(discord.Message, message))
+
+                assert "warning: discord: could not clear reactions" in caplog.text
+                assert "BAD REQUEST" in caplog.text

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,5 +1,6 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import discord
 import pytest
 
 from spellbot.reactions import safe_clear_reactions, safe_remove_reaction
@@ -16,16 +17,64 @@ class TestReactions:
         message = MockDiscordMessage()
         with patch.object(
             message, "remove_reaction", wraps=message.remove_reaction
-        ) as monkey:
+        ) as fake_message:
             await safe_remove_reaction(message, "emoji", FRIEND)
 
-            monkey.assert_called_with("emoji", FRIEND)
+            fake_message.assert_called_with("emoji", FRIEND)
+
+    async def test_safe_remove_reaction_sends_message_when_forbidden_exception_is_thrown(
+        self, channel_maker
+    ):
+        message = MockDiscordMessage()
+        with patch.object(
+            message, "remove_reaction", wraps=message.remove_reaction
+        ) as fake_message:
+            fake_http_response = Mock()
+            fake_http_response.status = 403
+            fake_message.side_effect = discord.errors.Forbidden(
+                fake_http_response, "Missing Permissions"
+            )
+            with patch.object(
+                message.channel, "send", wraps=message.channel.send
+            ) as fake_channel_send:
+                await safe_remove_reaction(message, "emoji", FRIEND)
+
+                fake_channel_send.assert_called_with(
+                    (
+                        "I do not have permission to adjust "
+                        "reactions. A server admin will need to adjust my permissions."
+                    )
+                )
 
     async def test_clear_reactions_clears_reactions_from_message(self, channel_maker):
         message = MockDiscordMessage()
         with patch.object(
             message, "clear_reactions", wraps=message.clear_reactions
-        ) as monkey:
+        ) as fake_message:
             await safe_clear_reactions(message)
 
-            monkey.assert_called()
+            fake_message.assert_called()
+
+    async def test_clear_reactions_sends_message_when_forbidden_exception_is_thrown(
+        self, channel_maker
+    ):
+        message = MockDiscordMessage()
+        with patch.object(
+            message, "clear_reactions", wraps=message.clear_reactions
+        ) as fake_message:
+            fake_http_response = Mock()
+            fake_http_response.status = 403
+            fake_message.side_effect = discord.errors.Forbidden(
+                fake_http_response, "Missing Permissions"
+            )
+            with patch.object(
+                message.channel, "send", wraps=message.channel.send
+            ) as fake_channel_send:
+                await safe_clear_reactions(message)
+
+                fake_channel_send.assert_called_with(
+                    (
+                        "I do not have permission to adjust "
+                        "reactions. A server admin will need to adjust my permissions."
+                    )
+                )


### PR DESCRIPTION
**Description**

Has spellbot message when it cannot adjust reactions because it lacks the proper permissions.

* Definitely not finished, since I didn't implement a way for admins to silence this message
* I chose to put the reactions code into their own file to make unit testing easier. If you'd prefer to consider these methods as private functions in the main test file, does that mean you want each place that calls them to be tested for this permissions message?
* Can't figure out why the meta test for strings doesn't work for this. Probably something to do with it being in a separate file?
* If you want to start pulling some of this code into smaller, more manageable files, is there a more programatic way to order the test files to ensure the Meta class gets invoked last, but not have to list every single test file?

- First step towards resolving #120 

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
