### PR TITLE
Support power levels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:
@@ -44,7 +44,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install sqlite3
-      run: sudo apt-get install sqlite3
+      run: |
+        sudo apt-get update
+        sudo apt-get install sqlite3
 
     - name: Install Dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v3.17.0](https://github.com/lexicalunit/spellbot/releases/tag/v3.17.0) - 2020-08-12
 
+### Changed
+
+- Added `apt-get update` to CI workflow.
+- Using a newer version of Ubuntu for CI.
+
+### Fixed
+
+- Fixed the migrations test so that it actually uses the CI configured database.
+- Fixed some typos in an old migration script.
+
 ### Added
 
 - Link to docker hub published image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A top.gg widget to the site.
 - Feedback section in the README.
 - Added links privacy server setting.
+- Added the !power command and support for power level matching.
 
 ## [v3.16.1](https://github.com/lexicalunit/spellbot/releases/tag/v3.16.1) - 2020-08-09
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Just looking to play some games of Magic? These commands are for you!
 - `!lfg`: Sign up to play Magic: The Gathering!
 - `!join`: Look for a game to join, but don't create a new one.
 - `!leave`: Leave any games that you've signed up for.
+- `!power`: Set your current power level.
 
 When you run the `!lfg` command, SpellBot will post a message for sign ups.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
             <li><code>!lfg</code>: Sign up to play <em>Magic: The Gathering</em>!</li>
             <li><code>!join</code>: Look for a game to join, but don’t create a new one.</li>
             <li><code>!leave</code>: Leave any games that you’ve signed up for.</li>
+            <li><code>!power</code>: Set your current power level.</li>
         </ul>
         <p>When you run the <code>!lfg</code> command, SpellBot will post a message for sign ups.</p>
         <img class="screenshot" src="https://user-images.githubusercontent.com/1903876/88854660-7a02c680-d1a6-11ea-9f12-75b9cbb439b4.png" alt="looking for game">

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -66,6 +66,9 @@ not_a_command: Sorry $reply, there is no "$request" command.
 not_admin: $reply, you do not have admin permissions to run that command.
 play_found: 'I found a game for you, $reply. You have been signed up for it! Go to
   game post: $link'
+power: Ok $reply, your power level has been set to $power.
+power_invalid: Sorry $reply, please provide a number between 1 to 10 or "none" to
+  unset.
 reaction_permissions_required: I do not have permission to adjust reactions. A server
   admin will need to adjust my permissions.
 spellbot_channels: 'Ok $reply, I will now operate within: $channels'

--- a/src/spellbot/versions/versions/0a01d60d4c38_removing_cruft_since_refactor.py
+++ b/src/spellbot/versions/versions/0a01d60d4c38_removing_cruft_since_refactor.py
@@ -25,15 +25,15 @@ def upgrade():
 
 def downgrade():
     with op.batch_alter_table("users") as b:
-        b.add_column(sa.Column("queued_at", sa.DATETIME(), nullable=True))
+        b.add_column(sa.Column("queued_at", sa.DateTime(), nullable=True))
     with op.batch_alter_table("games") as b:
-        b.add_column(sa.Column("power", sa.FLOAT(), nullable=True))
+        b.add_column(sa.Column("power", sa.Float(), nullable=True))
     op.create_table(
         "wait_times",
-        sa.Column("id", sa.INTEGER(), nullable=False),
-        sa.Column("guild_xid", sa.BIGINT(), nullable=False),
-        sa.Column("channel_xid", sa.BIGINT(), nullable=False),
-        sa.Column("created_at", sa.DATETIME(), nullable=False),
-        sa.Column("seconds", sa.INTEGER(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("guild_xid", sa.BigInteger(), nullable=False),
+        sa.Column("channel_xid", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("seconds", sa.Integer(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/src/spellbot/versions/versions/ba6af6c62640_adds_user_power_level.py
+++ b/src/spellbot/versions/versions/ba6af6c62640_adds_user_power_level.py
@@ -1,0 +1,25 @@
+"""Adds user power level
+
+Revision ID: ba6af6c62640
+Revises: 7a2698d54c8a
+Create Date: 2020-08-14 14:49:21.107946
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ba6af6c62640"
+down_revision = "7a2698d54c8a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("users") as b:
+        b.add_column(sa.Column("power", sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("users") as b:
+        b.drop_column("power")

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -11,6 +11,11 @@
 > 
 > Aliases: `!play`
 
+`!power <none | 1..10>`
+>  Set or unset the power level of the deck you are going to play.
+> 
+> When you have set a power level, the !lfg and !join commands will try to put you in games with other players of similar power levels.
+
 `!queue [size:N] [@player-1] [@player-2] ... [~tag-1] [~tag-2] ...`
 >  Add a player to an admin controller play queue. _Requires the "SpellBot Admin" role._
 > 
@@ -25,7 +30,3 @@
 > 
 > The following subcommands are supported:
 > * `config`: Just show the current configuration for this server.
-> * `channel <list>`: Set SpellBot to only respond in the given list of channels.
-> * `prefix <string>`: Set SpellBot's command prefix for text channels.
-> * `links <string>`: Set the privacy level for generated SpellTable links.
-> * `expire <number>`: Set the number of minutes before pending games expire.

--- a/tests/snapshots/test_on_message_help_2.txt
+++ b/tests/snapshots/test_on_message_help_2.txt
@@ -1,3 +1,7 @@
+> * `channel <list>`: Set SpellBot to only respond in the given list of channels.
+> * `prefix <string>`: Set SpellBot's command prefix for text channels.
+> * `links <string>`: Set the privacy level for generated SpellTable links.
+> * `expire <number>`: Set the number of minutes before pending games expire.
 > * `help`: Get detailed usage help for SpellBot.
 ---
 Please report any bugs and suggestions at <https://github.com/lexicalunit/spellbot/issues>!

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -2,11 +2,14 @@ class TestMigrations:
     def test_alembic(self, tmp_path):
         from sqlalchemy import create_engine
 
+        from spellbot import get_db_url
         from spellbot.data import create_all, reverse_all
 
         db_file = tmp_path / "spellbot.db"
-        connection_url = f"sqlite:///{db_file}"
-        engine = create_engine(connection_url)
+        connection_string = f"sqlite:///{db_file}"
+        db_url = get_db_url("TEST_SPELLBOT_DB_URL", connection_string)
+
+        engine = create_engine(db_url)
         connection = engine.connect()
-        create_all(connection, connection_url)
-        reverse_all(connection, connection_url)
+        create_all(connection, db_url)
+        reverse_all(connection, db_url)


### PR DESCRIPTION
**Description**

Adds support for a `!power` command that you can use to set the power level of your deck. You can also unset your power level with `!power none` or `!power 0` (and various other ways).

When set, there will be a new field for "Average Power Level" shown for your game:

![Screen Shot 2020-08-14 at 4 45 13 PM](https://user-images.githubusercontent.com/1903876/90300037-89903980-de4d-11ea-82c0-3d1c8d7322dc.png)

You will also see each individual player's power level next to their user name.

Additionally, when using the `!lfg` and `!join` commands, the bot will try to intelligently put you into a game with an appropriate average power level. If you don't have a power level set, this check is simply not done and you'll be placed into any available game.

- Resolves https://github.com/lexicalunit/spellbot/issues/151

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [ ] Entire test suite passes
