### PR TITLE
Re-enable expiration, add power vs none logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Updated to latest from beautiful-jekyll.
+- Re-enabled cleanup task for expired pending games.
+- When matching a player with power to a pending games, don't consider power-less games.
 
 ## [v3.18.0](https://github.com/lexicalunit/spellbot/releases/tag/v3.18.0) - 2020-08-14
 

--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -391,8 +391,7 @@ class SpellBot(discord.Client):
         self, loop: asyncio.AbstractEventLoop
     ) -> None:  # pragma: no cover
         """Start up any periodic background tasks."""
-        # TODO: Think about how to make this better...
-        # self.cleanup_expired_games_task(loop)
+        self.cleanup_expired_games_task(loop)
 
         # TODO: Make this manually triggered.
         # self.cleanup_started_games_task(loop)

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -256,6 +256,8 @@ class Game(Base):
         ]
         if power:
             having_filters.append(between(func.avg(User.power), power - 1, power + 1))
+        else:
+            select_filters.append(User.power == None)
         inner = (
             session.query(Game.id)
             .join(User, isouter=True)

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -2255,6 +2255,14 @@ class TestSpellBot:
         assert game_embed_for(client, AMY, False) != game_embed_for(client, JR, False)
         assert len(all_games(client)) == 2
 
+    async def test_on_message_lfg_with_power_vs_none(self, client, channel_maker):
+        channel = channel_maker.text()
+        await client.on_message(MockMessage(AMY, channel, "!power 5"))
+        await client.on_message(MockMessage(AMY, channel, "!lfg"))
+        await client.on_message(MockMessage(JR, channel, "!lfg"))
+        assert game_embed_for(client, AMY, False) != game_embed_for(client, JR, False)
+        assert len(all_games(client)) == 2
+
     async def test_paginate(self):
         def subject(text):
             return [page for page in spellbot.paginate(text)]


### PR DESCRIPTION
**Description**

- Re-enabled cleanup task for expired pending games.
- When matching a player with power to a pending games, don't consider power-less games.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [ ] Entire test suite passes
