### PR TITLE
Less verbose response to help command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Less verbose response to players using the !help command; now it uses emoji.
 - Less verbose response to players using the !power command; now it uses emoji.
 
 ## [v3.22.1](https://github.com/lexicalunit/spellbot/releases/tag/v3.22.1) - 2020-08-19

--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -884,9 +884,7 @@ class SpellBot(discord.Client):
             "<https://ko-fi.com/Y8Y51VTHZ>"
         )
         if str(message.channel.type) != "private":
-            await message.channel.send(
-                s("dm_sent", reply=f"<@{cast(discord.User, message.author).id}>")
-            )
+            await message.add_reaction("✅")
         for page in paginate(usage):
             await message.author.send(page)
 

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -6,7 +6,6 @@ begin_user_left: '**Warning:** A user left the server since this event was creat
   SpellBot did **NOT** start the game for the players: $players.'
 did_you_mean: 'Sorry $reply, that''s not a command. Did you mean to use one of these
   commands: $possible?'
-dm_sent: Right on $reply, I'll send you a Direct Message with details.
 event_bad_play_count: Sorry $reply, but the player count must be between 2 and 4.
 event_created: Ok $reply, I've created event $event_id! This event will have $count
   games. If everything looks good, next run `${prefix}begin $event_id` to start the

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -263,24 +263,23 @@ class TestSpellBot:
             snap(response)
         assert len(author.all_sent_calls) == 3
 
-    async def test_on_message_help_includes_confirmation_message_in_text_channel(
+    async def test_on_message_help_includes_confirmation_in_text_channel(
         self, client, channel_maker
     ):
         author = someone()
         channel = channel_maker.make("text")
-        await client.on_message(MockMessage(author, channel, "!help"))
-        assert len(channel.all_sent_calls) == 1
-        assert channel.last_sent_response == (
-            f"Right on <@{author.id}>, I'll send you a Direct Message with details."
-        )
+        msg = MockMessage(author, channel, "!help")
+        await client.on_message(msg)
+        assert "✅" in msg.reactions
 
-    async def test_on_message_help_does_not_include_confirmation_message_in_dm(
+    async def test_on_message_help_does_not_include_confirmation_in_dm(
         self, client, channel_maker
     ):
         author = someone()
         channel = channel_maker.make("dm")
-        await client.on_message(MockMessage(author, channel, "!help"))
-        assert len(channel.all_sent_calls) == 0
+        msg = MockMessage(author, channel, "!help")
+        await client.on_message(msg)
+        assert "✅" not in msg.reactions
 
     async def test_on_message_spellbot_dm(self, client, channel_maker):
         author = an_admin()
@@ -2016,8 +2015,9 @@ class TestSpellBot:
     async def test_on_message_spellbot_help(self, client, channel_maker):
         author = not_an_admin()
         channel = channel_maker.text()
-        await client.on_message(MockMessage(author, channel, "!spellbot help"))
-        assert len(channel.all_sent_calls) == 1
+        msg = MockMessage(author, channel, "!spellbot help")
+        await client.on_message(msg)
+        assert "✅" in msg.reactions
         assert len(author.all_sent_calls) >= 1
 
     async def test_on_message_queue_no_mentions(self, client, channel_maker):


### PR DESCRIPTION
**Description**

Less verbose response to players using the !help command. Just react to their message with an emoji.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
