### PR TITLE
Split up power levels 6 and 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds some logic to make sure that player with power 6 are never placed into a
+  game with average power level 7 or higher, and vice versa.
+
 ## [v3.22.5](https://github.com/lexicalunit/spellbot/releases/tag/v3.22.5) - 2020-08-21
 
 ### Fixed

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -340,6 +340,10 @@ class Game(Base):
         ]
         if power:
             having_filters.append(between(func.avg(User.power), power - 1, power + 1))
+            if power >= 7:
+                having_filters.append(func.avg(User.power) >= 7)
+            else:
+                having_filters.append(func.avg(User.power) < 7)
         else:
             select_filters.append(User.power == None)
         inner = (

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -2290,6 +2290,24 @@ class TestSpellBot:
         assert game_embed_for(client, AMY, False) != game_embed_for(client, JR, False)
         assert len(all_games(client)) == 2
 
+    async def test_on_message_lfg_with_power_6_vs_7(self, client, channel_maker):
+        channel = channel_maker.text()
+        await client.on_message(MockMessage(AMY, channel, "!power 6"))
+        await client.on_message(MockMessage(JR, channel, "!power 7"))
+        await client.on_message(MockMessage(AMY, channel, "!lfg"))
+        await client.on_message(MockMessage(JR, channel, "!lfg"))
+        assert game_embed_for(client, AMY, False) != game_embed_for(client, JR, False)
+        assert len(all_games(client)) == 2
+
+    async def test_on_message_lfg_with_power_7_vs_6(self, client, channel_maker):
+        channel = channel_maker.text()
+        await client.on_message(MockMessage(AMY, channel, "!power 7"))
+        await client.on_message(MockMessage(JR, channel, "!power 6"))
+        await client.on_message(MockMessage(AMY, channel, "!lfg"))
+        await client.on_message(MockMessage(JR, channel, "!lfg"))
+        assert game_embed_for(client, AMY, False) != game_embed_for(client, JR, False)
+        assert len(all_games(client)) == 2
+
     async def test_on_message_lfg_with_power_vs_none(self, client, channel_maker):
         channel = channel_maker.text()
         await client.on_message(MockMessage(AMY, channel, "!power 5"))


### PR DESCRIPTION
**Description**

Adds some logic to make sure that player with power 6 are never placed into a game with average power level 7 or higher, and vice versa.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
