### PR TITLE
Removes invites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Removes the all the invitation code paths, this code needs to be refactored.
+
 ### Changed
 
 - Updated screenshots.

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -40,18 +40,11 @@ game_too_few_mentions: Sorry $reply, you mentioned too few people. I expected $s
   players to be mentioned.
 game_too_many_mentions: Sorry $reply, you mentioned too many people. I expected $size
   players to be mentioned.
-invite_already_confirmed: Hi $reply, just letting you know that your invitation was
-  already confirmed.
-invite_confirmed: Thanks $reply, your invitation has been confirmed!
-invite_denied: Thank you for your response, $reply.
-invite_not_invited: Sorry $reply, but you do not currently have any pending invitations.
 leave: Ok $reply, you've been removed from the pending game that you were signed up
   for.
 leave_already: Sorry $reply, but you we're not in any pending games.
-lfg_invited: Hello $reply! You've been invited to a game by $mention. To confirm or
-  deny please respond with yes or no.
-lfg_mention_already: Sorry $reply, but $mention is already in another pending game
-  and can't be invited.
+lfg_mentions_different_games: Sorry $reply, but the users you mentioned are not all
+  in the same pending game.
 lfg_too_many_mentions: Sorry $reply, but you've mentioned too many players for that
   size game.
 no_dm: Hello $reply! That command only works in text channels.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -12,7 +12,6 @@ import alembic.config  # type: ignore
 import discord
 from sqlalchemy import (
     BigInteger,
-    Boolean,
     Column,
     DateTime,
     Float,
@@ -179,8 +178,6 @@ class User(Base):
         Integer, ForeignKey("games.id", ondelete="SET NULL"), nullable=True, index=True
     )
     cached_name = Column(String(50))
-    invited = Column(Boolean, server_default=text("false"), nullable=False)
-    invite_confirmed = Column(Boolean, server_default=text("false"), nullable=False)
     power = Column(Integer, nullable=True)
     game = relationship("Game", back_populates="users")
 
@@ -204,8 +201,6 @@ class User(Base):
             "xid": self.xid,
             "game_id": self.game_id,
             "cached_name": self.cached_name,
-            "invited": self.invited,
-            "invite_confirmed": self.invite_confirmed,
             "power": self.power,
         }
 

--- a/src/spellbot/versions/versions/a711319d9661_remove_invitation_columns.py
+++ b/src/spellbot/versions/versions/a711319d9661_remove_invitation_columns.py
@@ -1,0 +1,38 @@
+"""Remove invitation columns
+
+Revision ID: a711319d9661
+Revises: 60f9ffc05b0a
+Create Date: 2020-08-25 19:18:33.101446
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a711319d9661"
+down_revision = "60f9ffc05b0a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("users") as b:
+        b.drop_column("invite_confirmed")
+        b.drop_column("invited")
+
+
+def downgrade():
+    with op.batch_alter_table("users") as b:
+        b.add_column(
+            sa.Column(
+                "invited", sa.BOOLEAN(), server_default=sa.text("(false)"), nullable=False
+            ),
+        )
+        b.add_column(
+            sa.Column(
+                "invite_confirmed",
+                sa.BOOLEAN(),
+                server_default=sa.text("(false)"),
+                nullable=False,
+            ),
+        )

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -23,7 +23,7 @@
 > 
 > The default game size is 4 but you can change it by adding, for example, `size:2` to create a two player game.
 > 
-> You can automatically invite players to the game by @ mentioning them in the command. They will be sent invite confirmations and the game won't be posted to the channel until they've responded.
+> You can automatically join players already in a game by @ mentioning them in the command.
 > 
 > Players will be able to enter or leave the game by reacting to the message that SpellBot sends with the ✋ and 🚫 emoji.
 > 
@@ -53,3 +53,4 @@
 >  Configure SpellBot for your server. _Requires the "SpellBot Admin" role._
 > 
 > The following subcommands are supported:
+> * `config`: Just show the current configuration for this server.

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,4 +1,3 @@
-> * `config`: Just show the current configuration for this server.
 > * `channel <list>`: Set SpellBot to only respond in the given list of channels.
 > * `prefix <string>`: Set SpellBot's command prefix for text channels.
 > * `links <string>`: Set the privacy level for generated SpellTable links.
@@ -25,3 +24,6 @@
 > 
 > Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
 > * Optional: Add a message to DM players with `msg:` followed by whatever.
+> * Optional: Add up to five tags by using `~tag-name`.
+
+`!begin <event id>`

--- a/tests/snapshots/test_on_message_help_2.txt
+++ b/tests/snapshots/test_on_message_help_2.txt
@@ -1,7 +1,4 @@
-> > * Optional: Add up to five tags by using `~tag-name`.
-
-`!begin <event id>`
->  Confirm creation of games for the given event id. _Requires the "SpellBot Admin" role._
+> >  Confirm creation of games for the given event id. _Requires the "SpellBot Admin" role._
 ---
 Please report any bugs and suggestions at <https://github.com/lexicalunit/spellbot/issues>!
 


### PR DESCRIPTION
**Description**

Removes all the invitation code paths. This code was just really fully of ugly hacks and I don't think it's super useful anymore as people can easily just join the games they want to join with the emoji. I've left into the ability to "join up" with other people by @mentioning them. You can even @mention multiple users and it will work so long as all the mentioned users are in the same game.

**Checklist**

- [x] Add tests for these changes
- [-] Test coverage is not decreased
- [x] Entire test suite passes
