### PR TITLE
Put created voice channels into their own category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Puts created voice channels into a "SpellBot Voice Channels" category.
+
 ### Fixed
 
 - Fixed check for Authorization header to fail with 403 if not present.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -53,6 +53,7 @@ class Server(Base):
     links = Column(String(10), nullable=False, server_default=text("'public'"))
     power_enabled = Column(Boolean, nullable=False, server_default=true())
     create_voice = Column(Boolean, nullable=False, server_default=false())
+    voice_category_xid = Column(BigInteger)
     games = relationship("Game", back_populates="server", uselist=True)
     channels = relationship("Channel", back_populates="server", uselist=True)
     teams = relationship("Team", back_populates="server", uselist=True)

--- a/src/spellbot/versions/versions/e3ab9447b076_adds_voice_channels_category.py
+++ b/src/spellbot/versions/versions/e3ab9447b076_adds_voice_channels_category.py
@@ -1,0 +1,25 @@
+"""Adds voice channels category
+
+Revision ID: e3ab9447b076
+Revises: 311f7bbcdf77
+Create Date: 2020-10-12 16:06:46.843494
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e3ab9447b076"
+down_revision = "311f7bbcdf77"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("servers") as b:
+        b.add_column(sa.Column("voice_category_xid", sa.BigInteger(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("servers") as b:
+        b.drop_column("voice_category_xid")

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -194,6 +194,14 @@ def create_voice_channel_side_effect(*args, **kwargs):
     return MockVoiceChannel()
 
 
+def create_category_channel_side_effect(*args, **kwargs):
+    class MockCategoryChannel:
+        def __init__(self):
+            self.id = 2
+
+    return MockCategoryChannel()
+
+
 class MockGuild:
     def __init__(self, guild_id, name, members):
         self.id = guild_id
@@ -202,6 +210,10 @@ class MockGuild:
 
         self.create_voice_channel = AsyncMock(
             side_effect=create_voice_channel_side_effect
+        )
+
+        self.create_category_channel = AsyncMock(
+            side_effect=create_category_channel_side_effect
         )
 
 


### PR DESCRIPTION
**Description**

Put created voice channels into their own "SpellBot Voice Channels" category to keep them organized.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [ ] Entire test suite passes
