### PR TITLE
Automatically handle voice channel spillover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds voice channel overflow logic so that new categories get created automatically.
+
 ## [v4.9.0](https://github.com/lexicalunit/spellbot/releases/tag/v4.9.0) - 2020-10-16
 
 ### Changed

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -55,7 +55,6 @@ class Server(Base):
     power_enabled = Column(Boolean, nullable=False, server_default=true())
     tags_enabled = Column(Boolean, nullable=False, server_default=true())
     create_voice = Column(Boolean, nullable=False, server_default=false())
-    voice_category_xid = Column(BigInteger)
     games = relationship("Game", back_populates="server", uselist=True)
     channels = relationship("Channel", back_populates="server", uselist=True)
     teams = relationship("Team", back_populates="server", uselist=True)

--- a/src/spellbot/operations.py
+++ b/src/spellbot/operations.py
@@ -276,3 +276,23 @@ async def safe_create_invite(
             e,
         )
         return None
+
+
+async def safe_fetch_guild(
+    client: discord.Client, guild_xid: int
+) -> Optional[discord.Guild]:
+    guild = client.get_guild(guild_xid)
+    if guild:
+        return guild
+    try:
+        return await client.fetch_guild(guild_xid)
+    except (
+        discord.errors.Forbidden,
+        discord.errors.HTTPException,
+    ) as e:
+        logger.exception(
+            "warning: discord (guild %s): could not fetch guild: %s",
+            guild_xid,
+            e,
+        )
+        return None

--- a/src/spellbot/versions/versions/b2e707d342be_removes_server_voice_category_id_.py
+++ b/src/spellbot/versions/versions/b2e707d342be_removes_server_voice_category_id_.py
@@ -1,0 +1,25 @@
+"""Removes server voice category id tracking
+
+Revision ID: b2e707d342be
+Revises: 71ae365b621c
+Create Date: 2020-10-16 21:36:47.067762
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b2e707d342be"
+down_revision = "71ae365b621c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("servers") as b:
+        b.drop_column("voice_category_xid")
+
+
+def downgrade():
+    with op.batch_alter_table("servers") as b:
+        b.add_column(sa.Column("voice_category_xid", sa.BIGINT(), nullable=True))

--- a/tests/mocks/client.py
+++ b/tests/mocks/client.py
@@ -35,6 +35,9 @@ class MockDiscordClient:
     def get_guild(self, guild_id):
         return self._guild
 
+    async def fetch_guild(self, guild_id):
+        return self._guild
+
     async def fetch_channel(self, channel_id):
         return self.get_channel(channel_id)
 

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -212,6 +212,7 @@ class MockGuild:
         self.id = guild_id
         self.name = name
         self.members = members
+        self.categories = []
 
         self.create_voice_channel = AsyncMock(
             side_effect=create_voice_channel_side_effect


### PR DESCRIPTION
**Description**

Automatically create new categories for voice channels when we hit the 50 channel per category limit. Always choose the first available voice category for a new channel.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [x] Entire test suite passes
