### PR TITLE
Adds call attention lfg, soft delete expired, nix find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Don't completely delete expired game posts, just delete their content.
+
+### Added
+
+- Added the ability to @mention other players with lfg to create/find games with them.
+- You can now !lfg when you're in a pending game to "look for N more" players.
+
+### Removed
+
+- Removed the `!find` command as it was confusing and not useful.
+
 ## [v5.0.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.0.0) - 2020-10-17
 
 - New major version, no code changes.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ being too spammy in text channels.**
 
 Just looking to play some games of Magic? These commands are for you!
 
-- `!lfg`: Sign up to play Magic: The Gathering!
-- `!find`: Look for a game to join, but don't create a new one.
+- `!lfg`: Find or start up a game of Magic: The Gathering!
 - `!leave`: Leave any games that you've signed up for.
 - `!power`: Set your current power level.
 - `!report`: Report the results of the game you just played.

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,6 @@ description: "SpellBot is the Discord bot that helps you find other players look
         <p>Just looking to play some games of Magic? These commands are for you!</p>
         <ul>
             <li><code>!lfg</code>: Sign up to play <em>Magic: The Gathering</em>!</li>
-            <li><code>!find</code>: Look for a game to join, but don’t create a new one.</li>
             <li><code>!leave</code>: Leave any games that you’ve signed up for.</li>
             <li><code>!power</code>: Set your current power level.</li>
             <li><code>!report</code>: Report the results of the game you just played.</li>

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -4,6 +4,9 @@ begin_event_already_started: Sorry $reply, but that event has already started an
 begin_no_params: $reply, please provide the event ID with that command.
 begin_user_left: '**Warning:** A user left the server since this event was created.
   SpellBot did **NOT** start the game for the players: $players.'
+call_attn_desc: '[Jump to the game post]($link) to see it!'
+call_attn_title: Looking for ${remaining} more player${plural} to join...
+deleted_game: Sorry, this game was expired due to inactivity.
 did_you_mean: 'Sorry $reply, that''s not a command. Did you mean to use one of these
   commands: $possible?'
 event_bad_play_count: Sorry $reply, but the player count must be between 2 and 4.
@@ -34,14 +37,11 @@ game_created: '**Game $id created:**
   > Players notified by DM: $players'
 game_message_too_long: Sorry $reply, but the optional game message must be shorter
   than 255 characters.
-game_not_found: Sorry $reply, but I didn't find any games for you to join.
 game_size_bad: Sorry $reply, but the game size must be between 2 and 4.
 game_too_few_mentions: Sorry $reply, you mentioned too few people. I expected $size
   players to be mentioned.
 game_too_many_mentions: Sorry $reply, you mentioned too many people. I expected $size
   players to be mentioned.
-lfg_mentions_different_games: Sorry $reply, but the users you mentioned are not all
-  in the same pending game.
 lfg_too_many_mentions: Sorry $reply, but you've mentioned too many players for that
   size game.
 no_dm: Hello $reply! That command only works in text channels.

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -33,9 +33,6 @@
 `!help`
 >  Sends you this help message.
 
-`!find`
->  Works exactly like `!lfg` except that it will NOT create a new game.
-
 `!about`
 >  Get information about SpellBot.
 
@@ -48,3 +45,4 @@
 > * `config`: Just show the current configuration for this server.
 > * `channels <list>`: Set SpellBot to only respond in the given list of channels.
 > * `prefix <string>`: Set SpellBot's command prefix for text channels.
+> * `links <private | public>`: Set the privacy for generated SpellTable links.

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,4 +1,3 @@
-> * `links <private | public>`: Set the privacy for generated SpellTable links.
 > * `expire <number>`: Set the number of minutes before pending games expire.
 > * `teams <list | none>`: Sets the teams available on this server.
 > * `power <on | off>`: Turns the power command on or off for this server.
@@ -25,3 +24,6 @@
 > 
 > Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
 > * Optional: Add a message to DM players with `msg:` followed by whatever.
+> * Optional: Add up to five tags by using `~tag-name`.
+
+`!begin <event id>`

--- a/tests/snapshots/test_on_message_help_2.txt
+++ b/tests/snapshots/test_on_message_help_2.txt
@@ -1,7 +1,4 @@
-> > * Optional: Add up to five tags by using `~tag-name`.
-
-`!begin <event id>`
->  Confirm creation of games for the given event id. _Requires the "SpellBot Admin" role._
+> >  Confirm creation of games for the given event id. _Requires the "SpellBot Admin" role._
 ---
 Please report any bugs and suggestions at <https://github.com/lexicalunit/spellbot/issues>!
 


### PR DESCRIPTION
**Description**

### Changed

- Don't completely delete expired game posts, just delete their content.

### Added

- Added the ability to @mention other players with lfg to create/find games with them.
- You can now !lfg when you're in a pending game to "look for N more" players.

### Removed

- Removed the `!find` command as it was confusing and not useful.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [x] Entire test suite passes
