### PR TITLE
Disable the help command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the `!help` command, use `!spellbot help` instead.
+
 ### Fixed
 
 - Fixed an old invite link to have the correct permissions bits.
@@ -15,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Changed the logic around the expired games deletion background task to be more robust.
 - Added more information to the description of game posts to help users understand.
+- Ignore any `!help` messages, too many other bots use that command.
 
 ## [v5.1.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.1.0) - 2020-10-17
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Discord via the following commands in any of the authorized channels. **Keep in
 mind that sometimes SpellBot will respond to you via Direct Message to avoid
 being too spammy in text channels.**
 
-- `!help`: Provides detailed help about all of the following commands.
+- `!spellbot help`: Provides detailed help about all of the following commands.
 - `!about`: Get information about SpellBot and its creators.
 
 > **Note:** To use the

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
     <section id="bot-commands" class="level3">
         <h2>🤖 Bot Commands</h2>
         <ul>
-            <li><code>!help</code> or <code>!spellbot help</code>: Provides detailed usage help.</li>
+            <li><code>!spellbot help</code>: Provides detailed usage help.</li>
             <li><code>!about</code>: Get information about SpellBot and its creators.</li>
         </ul>
     </section>
@@ -45,7 +45,6 @@ description: "SpellBot is the Discord bot that helps you find other players look
             <li><code>!report</code>: Report the results of the game you just played.</li>
             <li><code>!team</code>: Join one of the teams available on your server.</li>
             <li><code>!points</code>: Find out how many points you currently have.</li>
-            <li><code>!help</code>: Provides detailed usage help.</li>
         </ul>
         <p>When you run the <code>!lfg</code> command, SpellBot will post a message for sign ups.</p>
         <img class="screenshot" src="https://user-images.githubusercontent.com/1903876/91242259-cedd2280-e6fb-11ea-8d30-e7127b6f96e9.png" alt="looking for game">

--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -688,6 +688,10 @@ class SpellBot(discord.Client):
             params.insert(0, request[5:])
             request = "power"
 
+        # Ignore !help because so many other bots use it, use `!spellbot help` instead.
+        if request.startswith("help"):
+            return
+
         matching = [command for command in self.commands if command.startswith(request)]
         if not matching:
             await message.channel.send(
@@ -903,7 +907,7 @@ class SpellBot(discord.Client):
     #
     # Where [foo] indicates foo is optional and <bar> indicates bar is required.
 
-    @command(allow_dm=True, help_group="Commands for Players")
+    # @command(allow_dm=True, help_group="Commands for Players")
     async def help(
         self, session: Session, prefix: str, params: List[str], message: discord.Message
     ) -> None:
@@ -982,7 +986,7 @@ class SpellBot(discord.Client):
         embed.description = (
             "_The Discord bot for [SpellTable](https://www.spelltable.com/)._\n"
             "\n"
-            f"Use the command `{prefix}help` for usage details. "
+            f"Use the command `{prefix}spellbot help` for usage details. "
             "Having issues with SpellBot? "
             "Please [report bugs](https://github.com/lexicalunit/spellbot/issues)!\n"
             "\n"

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -30,9 +30,6 @@
 `!leave`
 >  Leave any pending games that you've signed up.
 
-`!help`
->  Sends you this help message.
-
 `!about`
 >  Get information about SpellBot.
 

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -184,7 +184,7 @@ class TestSpellBot:
 
     async def test_on_message_non_text(self, client, channel_maker):
         channel = MockChannel(6, "voice")
-        await client.on_message(MockMessage(someone(), channel, "!help"))
+        await client.on_message(MockMessage(someone(), channel, "!spellbot help"))
         channel.sent.assert_not_called()
 
     @pytest.mark.parametrize("channel_type", ["dm", "text"])
@@ -284,14 +284,13 @@ class TestSpellBot:
     @pytest.mark.parametrize("channel_type", ["dm", "text"])
     async def test_on_message_from_a_bot(self, client, channel_maker, channel_type):
         channel = channel_maker.make(channel_type)
-        await client.on_message(MockMessage(BOT, channel, "!help"))
+        await client.on_message(MockMessage(BOT, channel, "!spellbot help"))
         assert len(channel.all_sent_calls) == 0
 
-    @pytest.mark.parametrize("channel_type", ["dm", "text"])
-    async def test_on_message_help(self, client, channel_maker, channel_type, snap):
+    async def test_on_message_help(self, client, channel_maker, snap):
         author = someone()
-        channel = channel_maker.make(channel_type)
-        await client.on_message(MockMessage(author, channel, "!help"))
+        channel = channel_maker.text()
+        await client.on_message(MockMessage(author, channel, "!spellbot help"))
         for response in author.all_sent_responses:
             snap(response)
         assert len(author.all_sent_calls) == 3
@@ -301,7 +300,7 @@ class TestSpellBot:
     ):
         author = someone()
         channel = channel_maker.make("text")
-        msg = MockMessage(author, channel, "!help")
+        msg = MockMessage(author, channel, "!spellbot help")
         await client.on_message(msg)
         assert "✅" in msg.reactions
 
@@ -310,7 +309,7 @@ class TestSpellBot:
     ):
         author = someone()
         channel = channel_maker.make("dm")
-        msg = MockMessage(author, channel, "!help")
+        msg = MockMessage(author, channel, "!spellbot help")
         await client.on_message(msg)
         assert "✅" not in msg.reactions
 
@@ -448,7 +447,9 @@ class TestSpellBot:
             f" <#{foo.id}>, <#{bar.id}>, <#{baz.id}>"
         )
         assert channel.last_sent_response == resp
-        await client.on_message(MockMessage(author, channel, "!help"))  # bad channel now
+        await client.on_message(
+            MockMessage(author, channel, "!spellbot help")
+        )  # bad channel now
         assert channel.last_sent_response == resp
 
         await client.on_message(MockMessage(author, foo, "!spellbot channels all"))
@@ -468,7 +469,8 @@ class TestSpellBot:
         assert about["description"] == (
             "_The Discord bot for [SpellTable](https://www.spelltable.com/)._\n"
             "\n"
-            "Use the command `!help` for usage details. Having issues with SpellBot? "
+            "Use the command `!spellbot help` for usage details. "
+            "Having issues with SpellBot? "
             "Please [report bugs](https://github.com/lexicalunit/spellbot/issues)!\n"
             "\n"
             "[🔗 Add SpellBot to your Discord!](https://discordapp.com/api/oauth2"
@@ -2015,12 +2017,12 @@ class TestSpellBot:
         channel = channel_maker.make(channel_type)
 
         @spellbot.command(allow_dm=True)
-        def mock_help(session, prefix, params, message):
+        def mock_cmd(session, prefix, params, message):
             raise RuntimeError("boom")
 
-        monkeypatch.setattr(client, "help", mock_help)
+        monkeypatch.setattr(client, "spellbot", mock_cmd)
         with pytest.raises(RuntimeError):
-            await client.on_message(MockMessage(someone(), channel, "!help"))
+            await client.on_message(MockMessage(someone(), channel, "!spellbot help"))
         assert "unhandled exception" in caplog.text
 
     async def test_on_message_spellbot_links_none(self, client, channel_maker):


### PR DESCRIPTION
**Description**

Disables the `!help` command. Too many other bots use it. We'll still respond to `!spellbot help` though.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
