### PR TITLE
Fix game embeds when spelltable has error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Game embeds now properly handle the case where the bot can not create a link.
+
 ## [v5.8.1](https://github.com/lexicalunit/spellbot/releases/tag/v5.8.1) - 2020-11-08
 
 ### Changed

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -593,9 +593,17 @@ class Game(Base):
             )
         elif self.system == "spelltable":
             if show_link:
-                description += (
-                    f"Click the link below to join your SpellTable game.\n<{self.url}>"
-                )
+                if self.url:
+                    description += (
+                        "Click the link below to join your SpellTable game."
+                        f"\n<{self.url}>"
+                    )
+                else:
+                    description += (
+                        "Sorry but SpellBot was unable to create a SpellTable link"
+                        " for this game. Please go to"
+                        " [spelltable.com](https://www.spelltable.com/) to create one.\n"
+                    )
             else:
                 description += (
                     "Please check your Direct Messages for your SpellTable link."

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -2926,6 +2926,22 @@ class TestSpellBot:
             game = session.query(Game).one_or_none()
             assert game.size == 3
 
+    async def test_spelltable_link_creation_failure(
+        self, client, channel_maker, monkeypatch
+    ):
+        channel = channel_maker.text()
+
+        mock_create_spelltable_url = Mock(return_value=None)
+        monkeypatch.setattr(client, "create_spelltable_url", mock_create_spelltable_url)
+
+        await client.on_message(MockMessage(AMY, channel, "!lfg size:2"))
+        await client.on_message(MockMessage(JR, channel, "!lfg size:2"))
+        assert game_embed_for(client, AMY, True)["description"] == (
+            "Sorry but SpellBot was unable to create a SpellTable link"
+            " for this game. Please go to"
+            " [spelltable.com](https://www.spelltable.com/) to create one.\n"
+        )
+
     async def test_paginate(self):
         def subject(text):
             return [page for page in spellbot.paginate(text)]


### PR DESCRIPTION
**Description**

Fixes an issue where the bot would create a wrong looking embed when SpellTable has a backend error.

**Before**

![Capture](https://user-images.githubusercontent.com/1903876/98731123-1a45bb00-2352-11eb-9210-aaa464469dc9.png)

**After**

![Screen Shot 2020-11-10 at 12 44 11 PM](https://user-images.githubusercontent.com/1903876/98731495-ab1c9680-2352-11eb-8dbd-982686c2c48d.png)

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
