### PR TITLE
Use members intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The old `user_teams` table has been refactored into a generic `user_server_settings`
   that can contain any users settings related to a specific server, such as teams
   and verification status. The affected sql scripts have been updated.
+- Use privileged members intents to find members by name.
 
 ## [v5.9.3](https://github.com/lexicalunit/spellbot/releases/tag/v5.9.3) - 2020-11-18
 

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -106,6 +106,7 @@ def send_side_effect(*args, **kwargs):
 class MockMember:
     def __init__(self, member_name, member_id, roles=[], admin=False, owner=False):
         self.name = member_name
+        self.nick = None
         self.id = member_id
         self.roles = roles
         self.avatar_url = "http://example.com/avatar.png"


### PR DESCRIPTION
**Description**

Adds members intents so that matchmaking via csv files works again.

This is currently blocked by Discord support whitelisting SpellBot for members intents privileges. I have a support ticket in progress for this: https://support.discord.com/hc/en-us/requests/9781448

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
