### PR TITLE
Adds user verification support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds the `!spellbot toggle-verify` command that toggles the verification
+  requirements for the channel that the command is ran within. Unverified users
+  will be unable to use SpellBot in channels that require verification.
+- Adds a `!verify` command that can be used to verify users mentioned.
+- Adds an `!unverify` command that does the opposite of `!verify`.
+
+### Changed
+
+- The old `user_teams` table has been refactored into a generic `user_server_settings`
+  that can contain any users settings related to a specific server, such as teams
+  and verification status. The affected sql scripts have been updated.
+
 ## [v5.9.3](https://github.com/lexicalunit/spellbot/releases/tag/v5.9.3) - 2020-11-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ These commands will help you configure SpellBot for your server.
   - `smotd`: Set the server message of the day.
   - `motd`: Set the privacy level for messages of the day.
   - `size`: Sets the default game size for a specific channel.
+  - `toggle-verify`: Toggles requirement of verification for a specific channel.
   - `stats`: Gets some statistics about SpellBot usage on your server.
   - `help`: Get detailed usage help for SpellBot.
+- `!verify`: Allows moderators to verify a user on their server.
+- `!unverify`: Un-verifies a user for this server.
 
 ### 🛋️ Ergonomics
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,10 +83,13 @@ description: "SpellBot is the Discord bot that helps you find other players look
                     <li><code>smotd</code>: Set the server message of the day.</li>
                     <li><code>motd</code>: Set the privacy level for messages of the day.</li>
                     <li><code>size</code>: Sets the default game size for a specific channel.</li>
+                    <li><code>toggle-verify</code>: Toggles requirement of verification for a specific channel.</li>
                     <li><code>stats</code>: Gets some statistics about SpellBot usage on your server.</li>
                     <li><code>help</code>: Provides detailed usage help.</li>
                 </ul>
             </li>
+            <li><code>!verify</code>: Allows moderators to verify a user on their server.</li>
+            <li><code>!unverify</code>: Un-verifies a user for this server.</li>
         </ul>
     </section>
     <section id="ergonomics" class="level3">

--- a/sql/points-by-team.sql
+++ b/sql/points-by-team.sql
@@ -2,8 +2,8 @@ SELECT
     teams.name AS team
     , SUM(user_points.points) AS points
 FROM users
-JOIN user_teams ON user_teams.user_xid = users.xid
+JOIN user_server_settings ON user_server_settings.user_xid = users.xid
 JOIN user_points ON user_points.user_xid = users.xid
-JOIN teams ON teams.id = user_teams.team_id
+JOIN teams ON teams.id = user_server_settings.team_id
 GROUP BY team
 ;

--- a/sql/teams-by-users.sql
+++ b/sql/teams-by-users.sql
@@ -3,11 +3,11 @@ SELECT
     , COUNT(1) as members
     , ROUND(COUNT(1) * 1.0 / (
         SELECT COUNT(1)
-        FROM user_teams
+        FROM user_server_settings
     ) * 100.0) AS percent
 FROM teams
-JOIN user_teams ON user_teams.team_id = teams.id
-JOIN users ON users.xid = user_teams.user_xid
+JOIN user_server_settings ON user_server_settings.team_id = teams.id
+JOIN users ON users.xid = user_server_settings.user_xid
 GROUP BY team
 ORDER BY members DESC
 LIMIT 10

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -48,6 +48,8 @@ no_dm: Hello $reply! That command only works in text channels.
 not_a_command: Sorry $reply, there is no "$request" command. Try "${prefix}spellbot
   help" for usage help.
 not_admin: $reply, you do not have admin permissions to run that command.
+not_verified: Hello $reply. You are not verified to use SpellBot in $channel. Please
+  speak to a server moderator or administrator to get verified.
 play_found_desc: You can [jump to the game post]($link) to see it, $reply!
 play_found_title: I found a game for you!
 points: You've got $points points, $reply.
@@ -103,6 +105,7 @@ spellbot_teams_none: Sorry $reply, but please provide a list of team names or `n
   to erase teams.
 spellbot_teams_too_few: Sorry $reply, but please give at least two team names or `none`
   to erase teams.
+spellbot_toggle_verify: Ok $reply, verification is now $setting for this channel.
 spellbot_unknown_subcommand: Sorry $reply, but the subcommand "$command" is not recognized.
 spellbot_voice: Ok $reply, I've turned $setting automatic voice channel creation.
 spellbot_voice_bad: Sorry $reply, but please provide an "on" or "off" setting.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -154,7 +154,7 @@ class Team(Base):
         rows = (
             session.query(Team.name, func.sum(UserPoints.points))
             .select_from(User)
-            .join(UserTeam)
+            .join(UserServerSettings)
             .join(UserPoints)
             .join(Team)
             .filter(Team.guild_xid == guild_xid)
@@ -191,6 +191,7 @@ class ChannelSettings(Base):
         index=True,
     )
     default_size = Column(Integer, nullable=True)
+    require_verification = Column(Boolean, nullable=False, server_default=false())
     server = relationship("Server", back_populates="channel_settings")
 
 
@@ -266,15 +267,16 @@ class User(Base):
 
     def to_json(self) -> dict:
         return {
-            "xid": self.xid,
-            "game_id": self.game_id,
             "cached_name": self.cached_name,
+            "created_at": str(self.created_at),
+            "game_id": self.game_id,
             "power": self.power,
+            "xid": self.xid,
         }
 
 
-class UserTeam(Base):
-    __tablename__ = "user_teams"
+class UserServerSettings(Base):
+    __tablename__ = "user_server_settings"
     user_xid = Column(
         BigInteger,
         ForeignKey("users.xid", ondelete="CASCADE"),
@@ -287,7 +289,8 @@ class UserTeam(Base):
         primary_key=True,
         nullable=False,
     )
-    team_id = Column(Integer, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False)
+    team_id = Column(Integer, ForeignKey("teams.id", ondelete="CASCADE"), nullable=True)
+    verified = Column(Boolean, nullable=True, server_default=false())
 
 
 class UserPoints(Base):

--- a/src/spellbot/versions/versions/3398862dc040_add_verification_requirement_toggle_to_.py
+++ b/src/spellbot/versions/versions/3398862dc040_add_verification_requirement_toggle_to_.py
@@ -1,0 +1,32 @@
+"""Add verification requirement toggle to channel settings
+
+Revision ID: 3398862dc040
+Revises: 1164f70e8dbe
+Create Date: 2020-11-19 12:41:09.869576
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3398862dc040"
+down_revision = "1164f70e8dbe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("channel_settings") as b:
+        b.add_column(
+            sa.Column(
+                "require_verification",
+                sa.Boolean(),
+                server_default=sa.false(),
+                nullable=False,
+            ),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("channel_settings") as b:
+        b.drop_column("require_verification")

--- a/src/spellbot/versions/versions/aa4e7f42cd91_add_verified_column_to_user_server_.py
+++ b/src/spellbot/versions/versions/aa4e7f42cd91_add_verified_column_to_user_server_.py
@@ -1,0 +1,27 @@
+"""Add verified column to user server settings
+
+Revision ID: aa4e7f42cd91
+Revises: da6dc39b4882
+Create Date: 2020-11-19 15:04:17.953982
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "aa4e7f42cd91"
+down_revision = "da6dc39b4882"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("user_server_settings") as b:
+        b.add_column(
+            sa.Column("verified", sa.Boolean(), server_default=sa.false(), nullable=True),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("user_server_settings") as b:
+        b.drop_column("verified")

--- a/src/spellbot/versions/versions/da6dc39b4882_rename_user_teams_to_user_server_.py
+++ b/src/spellbot/versions/versions/da6dc39b4882_rename_user_teams_to_user_server_.py
@@ -1,0 +1,59 @@
+"""Rename user_teams to user_server_settings
+
+Revision ID: da6dc39b4882
+Revises: 3398862dc040
+Create Date: 2020-11-19 14:44:55.671984
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "da6dc39b4882"
+down_revision = "3398862dc040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "user_server_settings",
+        sa.Column("user_xid", sa.BigInteger(), nullable=False),
+        sa.Column("guild_xid", sa.BigInteger(), nullable=False),
+        sa.Column("team_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["guild_xid"], ["servers.guild_xid"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_xid"], ["users.xid"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_xid", "guild_xid"),
+    )
+    conn = op.get_bind()
+    conn.execute(
+        """
+        INSERT INTO user_server_settings (user_xid, guild_xid, team_id)
+        SELECT user_xid, guild_xid, team_id
+        FROM user_teams;
+    """
+    )
+    op.drop_table("user_teams")
+
+
+def downgrade():
+    op.create_table(
+        "user_teams",
+        sa.Column("user_xid", sa.BIGINT(), nullable=False),
+        sa.Column("guild_xid", sa.BIGINT(), nullable=False),
+        sa.Column("team_id", sa.INTEGER(), nullable=False),
+        sa.ForeignKeyConstraint(["guild_xid"], ["servers.guild_xid"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_xid"], ["users.xid"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_xid", "guild_xid"),
+    )
+    conn = op.get_bind()
+    conn.execute(
+        """
+        INSERT INTO user_teams (user_xid, guild_xid, team_id)
+        SELECT user_xid, guild_xid, team_id
+        FROM user_server_settings;
+    """
+    )
+    op.drop_table("user_server_settings")

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -251,6 +251,7 @@ class MockChannel:
             content,
             **{param: value for param, value in kwargs.items() if value is not None},
         )
+        self.last_sent_message.channel = self
         self.messages.append(self.last_sent_message)
         return self.last_sent_message
 

--- a/tests/snapshots/test_on_message_spellbot_help_0.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_0.txt
@@ -35,6 +35,12 @@
 
 **### Commands for Admins ###**
 
+`!verify`
+>  Verify a user on your server.
+
+`!unverify`
+>  Unverify a user on your server.
+
 `!spellbot <subcommand> [subcommand parameters]`
 >  Configure SpellBot for your server. _Requires the "SpellBot Admin" role._
 > 
@@ -42,4 +48,3 @@
 > * `config`: Just show the current configuration for this server.
 > * `channels <list>`: Set SpellBot to only respond in the given list of channels.
 > * `prefix <string>`: Set SpellBot's command prefix for text channels.
-> * `links <private|public>`: Set the privacy for generated SpellTable links.

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -1,3 +1,4 @@
+> * `links <private|public>`: Set the privacy for generated SpellTable links.
 > * `expire <number>`: Set the number of minutes before pending games expire.
 > * `teams <list|none>`: Sets the teams available on this server.
 > * `power <on|off>`: Turns the power command on or off for this server.
@@ -6,6 +7,7 @@
 > * `smotd <your message>`: Set the server message of the day.
 > * `motd <private|public|both>`: Set the visibility of MOTD in game posts.
 > * `size <integer>`: Sets the default game size for a specific channel.
+> * `toggle-verify`: Toggles user verification on/off for a specific channel.
 > * `stats`: Gets some statistics about SpellBot usage on your server.
 > * `help`: Get detailed usage help for SpellBot.
 
@@ -24,4 +26,4 @@
 `!event <column 1> <column 2> ... [~tag-1 ~tag-2 ...] [msg: An optional message!]`
 >  Create many games in batch from an attached CSV data file. _Requires the "SpellBot Admin" role._
 > 
-> For example, if your event is for a Modern tournement you might attach a CSV file with a comment like `!event Player1Username Player2Username`. This would assume that the players' discord user names are found in the "Player1Username" and "Player2Username" CSV columns. The game size is deduced from the number of column names given, so we know the games created in this example are `size:2`.
+> For example, if your event is for a Modern tournement you might attach a CSV file with a comment like `!event Player1Username Player2Username`. This would assume that the players' discord user names are found in the "Player1Username" and "Player2Username" CSV columns.

--- a/tests/snapshots/test_on_message_spellbot_help_2.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_2.txt
@@ -1,4 +1,6 @@
-> > Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
+>  The game size is deduced from the number of column names given, so we know the games created in this example are `size:2`.
+> 
+> Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
 > * Optional: Add a message to DM players with `msg:` followed by whatever.
 > * Optional: Add up to five tags by using `~tag-name`.
 

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -96,8 +96,9 @@ class TestCodebase:
     def test_subcommands_documented(self, client):
         """Checks that all subcommands are documented in the spellbot() docstring."""
         documented = set(
-            re.findall(
-                r"^ *\* `([a-z]+) ?[^`]*`: .*$", client.spellbot.__doc__, re.MULTILINE
+            found.replace("-", "_")
+            for found in re.findall(
+                r"^ *\* `([a-z-]+) ?[^`]*`: .*$", client.spellbot.__doc__, re.MULTILINE
             )
         )
         implemented = set(client.subcommands)
@@ -109,7 +110,10 @@ class TestCodebase:
         with open(REPO_ROOT / "README.md") as f:
             readme = f.read()
 
-        documented = set(re.findall(r"^  - `([a-z]+)`: .*$", readme, re.MULTILINE))
+        documented = set(
+            found.replace("-", "_")
+            for found in re.findall(r"^  - `([a-z-]+)`: .*$", readme, re.MULTILINE)
+        )
         implemented = set(client.subcommands)
 
         assert documented == implemented
@@ -120,7 +124,10 @@ class TestCodebase:
             index = f.read()
 
         documented = set(
-            re.findall(r"^ *<li><code>([a-z]+)</code>: .*$", index, re.MULTILINE)
+            found.replace("-", "_")
+            for found in re.findall(
+                r"^ *<li><code>([a-z-]+)</code>: .*$", index, re.MULTILINE
+            )
         )
         implemented = set(client.subcommands)
 


### PR DESCRIPTION
**Description**

### Added

- Adds the `!spellbot toggle-verify` command that toggles the verification requirements for the channel that the command is ran within. Unverified users will be unable to use SpellBot in channels that require verification.
- Adds a `!verify` command that can be used to verify users mentioned.
- Adds an `!unverify` command that does the opposite of `!verify`.

### Changed

- The old `user_teams` table has been refactored into a generic `user_server_settings`
  that can contain any users settings related to a specific server, such as teams
  and verification status. The affected sql scripts have been updated.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
