### PR TITLE
Adds custom channel verify message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Adds a `!verify` command that can be used to verify users mentioned.
 - Adds an `!unverify` command that does the opposite of `!verify`.
 - Adds a `!spellbot cmotd` command to set the channel message of the day.
+- Adds a `!spellbot verify-message` command to set the not verified message for a channel.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ These commands will help you configure SpellBot for your server.
   - `motd`: Set the privacy level for messages of the day.
   - `size`: Sets the default game size for a specific channel.
   - `toggle-verify`: Toggles requirement of verification for a specific channel.
+  - `verify-message`: Set the verification message for a specific channel.
   - `stats`: Gets some statistics about SpellBot usage on your server.
   - `help`: Get detailed usage help for SpellBot.
 - `!verify`: Allows moderators to verify a user on their server.

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,6 +85,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
                     <li><code>motd</code>: Set the privacy level for messages of the day.</li>
                     <li><code>size</code>: Sets the default game size for a specific channel.</li>
                     <li><code>toggle-verify</code>: Toggles requirement of verification for a specific channel.</li>
+                    <li><code>verify-message</code>: Set the verification message for a specific channel.</li>
                     <li><code>stats</code>: Gets some statistics about SpellBot usage on your server.</li>
                     <li><code>help</code>: Provides detailed usage help.</li>
                 </ul>

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -110,6 +110,9 @@ spellbot_teams_too_few: Sorry $reply, but please give at least two team names or
   to erase teams.
 spellbot_toggle_verify: Ok $reply, verification is now $setting for this channel.
 spellbot_unknown_subcommand: Sorry $reply, but the subcommand "$command" is not recognized.
+spellbot_verify_message: 'Right on, $reply. The verification message for this channel
+  is now: $msg'
+spellbot_verify_message_too_long: Sorry $reply, but that message is too long.
 spellbot_voice: Ok $reply, I've turned $setting automatic voice channel creation.
 spellbot_voice_bad: Sorry $reply, but please provide an "on" or "off" setting.
 tags_too_many: Sorry $reply, but you can not use more than 5 tags.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -197,6 +197,7 @@ class ChannelSettings(Base):
     default_size = Column(Integer, nullable=True)
     require_verification = Column(Boolean, nullable=False, server_default=false())
     cmotd = Column(String(255))
+    verify_message = Column(String(255))
     server = relationship("Server", back_populates="channel_settings")
 
 

--- a/src/spellbot/versions/versions/d29a8fff2485_add_custom_verification_message.py
+++ b/src/spellbot/versions/versions/d29a8fff2485_add_custom_verification_message.py
@@ -1,0 +1,27 @@
+"""Add custom verification message
+
+Revision ID: d29a8fff2485
+Revises: 9172ecfb68e5
+Create Date: 2020-11-22 19:46:50.601875
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d29a8fff2485"
+down_revision = "9172ecfb68e5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("channel_settings") as b:
+        b.add_column(
+            sa.Column("verify_message", sa.String(length=255), nullable=True),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("channel_settings") as b:
+        b.drop_column("verify_message")

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -9,6 +9,7 @@
 > * `motd <private|public|both>`: Set the visibility of MOTD in game posts.
 > * `size <integer>`: Sets the default game size for a specific channel.
 > * `toggle-verify`: Toggles user verification on/off for a specific channel.
+> * `verify-message`: Set the verification message for a specific channel.
 > * `stats`: Gets some statistics about SpellBot usage on your server.
 > * `help`: Get detailed usage help for SpellBot.
 
@@ -26,5 +27,3 @@
 
 `!event <column 1> <column 2> ... [~tag-1 ~tag-2 ...] [msg: An optional message!]`
 >  Create many games in batch from an attached CSV data file. _Requires the "SpellBot Admin" role._
-> 
-> For example, if your event is for a Modern tournement you might attach a CSV file with a comment like `!event Player1Username Player2Username`.

--- a/tests/snapshots/test_on_message_spellbot_help_2.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_2.txt
@@ -1,4 +1,4 @@
->  This would assume that the players' discord user names are found in the "Player1Username" and "Player2Username" CSV columns. The game size is deduced from the number of column names given, so we know the games created in this example are `size:2`.
+> > For example, if your event is for a Modern tournement you might attach a CSV file with a comment like `!event Player1Username Player2Username`. This would assume that the players' discord user names are found in the "Player1Username" and "Player2Username" CSV columns. The game size is deduced from the number of column names given, so we know the games created in this example are `size:2`.
 > 
 > Games will not be created immediately. This is to allow you to verify things look ok. This command will also give you directions on how to actually start the games for this event as part of its reply.
 > * Optional: Add a message to DM players with `msg:` followed by whatever.

--- a/tests/test_spellbot.py
+++ b/tests/test_spellbot.py
@@ -3416,3 +3416,49 @@ class TestSpellBot:
 
         assert not user_has_game(client, JR)
         assert not user_has_game(client, AMY)
+
+    async def test_on_message_spellbot_verify_message(self, client, channel_maker):
+        admin = an_admin()
+        channel = channel_maker.text()
+        await client.on_message(
+            MockMessage(admin, channel, "!spellbot verify-message What the heck?")
+        )
+        assert channel.last_sent_response == (
+            f"Right on, {admin.mention}. "
+            "The verification message for this channel is now: What the heck?"
+        )
+
+        await client.on_message(MockMessage(admin, channel, "!spellbot toggle-verify"))
+        await client.on_message(MockMessage(AMY, channel, "!points"))
+        assert AMY.last_sent_response == "What the heck?"
+
+    async def test_on_message_spellbot_verify_message_none(self, client, channel_maker):
+        admin = an_admin()
+        channel = channel_maker.text()
+
+        await client.on_message(
+            MockMessage(admin, channel, "!spellbot verify-message something")
+        )
+        assert channel.last_sent_response == (
+            f"Right on, {admin.mention}."
+            " The verification message for this channel is now: something"
+        )
+
+        await client.on_message(MockMessage(admin, channel, "!spellbot verify-message"))
+        assert channel.last_sent_response == (
+            f"Right on, {admin.mention}."
+            " The verification message for this channel is now: "
+        )
+
+    async def test_on_message_spellbot_verify_message_too_long(
+        self, client, channel_maker
+    ):
+        admin = an_admin()
+        channel = channel_maker.text()
+        msg = "foo" * 100
+        await client.on_message(
+            MockMessage(admin, channel, f"!spellbot verify-message {msg}")
+        )
+        assert channel.last_sent_response == (
+            f"Sorry {admin.mention}, but that message is too long."
+        )


### PR DESCRIPTION
**Description**

Adds a `!spellbot verify-message` command to set the not verified message for a channel.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
