### PR TITLE
Adds spectate settings for servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Adds GraphQL, security alerts, security policy, and badge.
+- Allow servers to turn on a setting for showing spectator links.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ These commands will help you configure SpellBot for your server.
   - `channels`: Set the channels SpellBot is allowed to operate within.
   - `prefix`: Set the command prefix for SpellBot in text channels.
   - `links`: Set the privacy level for generated SpellTable links.
+  - `spectate`: Add a spectator link to the posts SpellBot makes.
   - `expire`: Set how many minutes before games are expired due to inactivity.
   - `teams`: Sets the teams available on this server.
   - `power`: Turns the power command on or off for this server.

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,6 +75,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
                     <li><code>channels</code>: Set the channels SpellBot is allowed to operate within.</li>
                     <li><code>prefix</code>: Set the command prefix for SpellBot in text channels.</li>
                     <li><code>links</code>: Set the privacy level for generated SpellTable links.</li>
+                    <li><code>spectate</code>: Add a spectator link to the posts SpellBot makes.</li>
                     <li><code>expire</code>: Set how many minutes before games are expired due to inactivity.</li>
                     <li><code>teams</code>: Sets the teams available on this server.</li>
                     <li><code>power</code>: Turns the power command on or off for this server.</li>

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -102,6 +102,8 @@ spellbot_size_bad: Sorry $reply, but default game size should be between 2 and 4
 spellbot_size_none: Sorry $reply, but please provide a number of players.
 spellbot_smotd: 'Right on, $reply. The server message of the day is now: $motd'
 spellbot_smotd_too_long: Sorry $reply, but that message is too long.
+spellbot_spectate: Ok $reply, I've turned the show spectator link setting $setting.
+spellbot_spectate_bad: Sorry $reply, but please provide an "on" or "off" setting.
 spellbot_tags: Ok $reply, I've turned the ability to use tags $setting.
 spellbot_tags_bad: Sorry $reply, but please provide an "on" or "off" setting.
 spellbot_teams_none: Sorry $reply, but please provide a list of team names or `none`

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -56,6 +56,7 @@ class Server(Base):
     prefix = Column(String(10), nullable=False, default="!")
     expire = Column(Integer, nullable=False, server_default=text("30"))  # minutes
     links = Column(String(10), nullable=False, server_default=text("'public'"))
+    show_spectate_link = Column(Boolean, nullable=False, server_default=false())
     motd = Column(String(10), nullable=False, server_default=text("'both'"))
     power_enabled = Column(Boolean, nullable=False, server_default=true())
     tags_enabled = Column(Boolean, nullable=False, server_default=true())
@@ -135,6 +136,7 @@ class Server(Base):
                 "guild_xid": self.guild_xid,
                 "prefix": self.prefix,
                 "expire": self.expire,
+                "show_spectate_link": self.show_spectate_link,
                 "channels": [channel.channel_xid for channel in self.channels],
                 "teams": [team.name for team in self.teams],
             }
@@ -630,6 +632,11 @@ class Game(Base):
                         "Click the link below to join your SpellTable game."
                         f"\n<{self.url}>"
                     )
+                    if self.server.show_spectate_link:
+                        description += (
+                            "\nOr spectate on the game with the following link."
+                            f"\n<{self.url}?spectate>"
+                        )
                 else:
                     description += (
                         "Sorry but SpellBot was unable to create a SpellTable link"

--- a/src/spellbot/versions/versions/a1d4bbcc2831_adds_server_spectator_link_settings.py
+++ b/src/spellbot/versions/versions/a1d4bbcc2831_adds_server_spectator_link_settings.py
@@ -1,0 +1,32 @@
+"""Adds server spectator link settings
+
+Revision ID: a1d4bbcc2831
+Revises: d29a8fff2485
+Create Date: 2020-12-04 16:22:18.842717
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1d4bbcc2831"
+down_revision = "d29a8fff2485"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("servers") as b:
+        b.add_column(
+            sa.Column(
+                "show_spectate_link",
+                sa.Boolean(),
+                server_default=sa.false(),
+                nullable=False,
+            ),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("servers") as b:
+        b.drop_column("show_spectate_link")

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -1,4 +1,5 @@
 > * `links <private|public>`: Set the privacy for generated SpellTable links.
+> * `spectate <on|off>`: Add a spectator link to the posts SpellBot makes.
 > * `expire <number>`: Set the number of minutes before pending games expire.
 > * `teams <list|none>`: Sets the teams available on this server.
 > * `power <on|off>`: Turns the power command on or off for this server.


### PR DESCRIPTION
**Description**

Lets servers turn on "show spectator links" mode.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
