### PR TITLE
Adds support for game command voice channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- The `!game` command will now create voice channels if that's enabled for the server.
+  And the new `!spellbot voice-category` command will define the category channel
+  that these created voice channels will be put into. The default is to use the
+  same category as the voice channels that are created by `!lfg`.
+
 ## [v5.16.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.16.0) - 2021-01-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These commands will help you configure SpellBot for your server.
   - `toggle-verify`: Toggles requirement of verification for a specific channel.
   - `auto-verify`: Set the channels that will trigger user auto verification.
   - `verify-message`: Set the verification message for a specific channel.
+  - `voice-category`: Set category for voice channels created by !game.
   - `stats`: Gets some statistics about SpellBot usage on your server.
   - `help`: Get detailed usage help for SpellBot.
 - `!verify`: Allows moderators to verify a user on their server.

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,6 +86,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
                     <li><code>toggle-verify</code>: Toggles requirement of verification for a specific channel.</li>
                     <li><code>auto-verify</code>: Set the channels that will trigger user auto verification.</li>
                     <li><code>verify-message</code>: Set the verification message for a specific channel.</li>
+                    <li><code>voice-category</code>: Set category for voice channels created by !game.</li>
                     <li><code>stats</code>: Gets some statistics about SpellBot usage on your server.</li>
                     <li><code>help</code>: Provides detailed usage help.</li>
                 </ul>

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -41,6 +41,15 @@ game_created: '**Game $id created:**
   > Spectate: <${url}?spectate>
 
   > Players notified by DM: $players'
+game_created_with_voice: '**Game $id created:**
+
+  > Game: <$url>
+
+  > Voice: <$voice>
+
+  > Spectate: <${url}?spectate>
+
+  > Players notified by DM: $players'
 game_message_too_long: Sorry $reply, but the optional game message must be shorter
   than 255 characters.
 game_size_bad: Sorry $reply, but the game size must be between 2 and 4.
@@ -129,6 +138,9 @@ spellbot_verify_message: 'Right on, $reply. The verification message for this ch
 spellbot_verify_message_too_long: Sorry $reply, but that message is too long.
 spellbot_voice: Ok $reply, I've turned $setting automatic voice channel creation.
 spellbot_voice_bad: Sorry $reply, but please provide an "on" or "off" setting.
+spellbot_voice_category: 'Right on, $reply. The voice channels that the game command
+  creates will be put into a category named: $category'
+spellbot_voice_category_too_long: Sorry $reply, but that category name is too long.
 tags_too_many: Sorry $reply, but you can not use more than 5 tags.
 team_gone: Sorry $reply, but the teams on this server have changed and your team no
   longer exists. Please choose a new team.

--- a/src/spellbot/constants.py
+++ b/src/spellbot/constants.py
@@ -22,5 +22,7 @@ EMOJI_FAIL = "❌"
 EMOJI_JOIN_GAME = "✋"
 EMOJI_OK = "✅"
 
+VOICE_CATEGORY_PREFIX = "SpellBot Voice Channels"
+
 VOICE_INVITE_EXPIRE_TIME_S = 600  # ten minutes, make this configurable?
 CLEAN_S = 7  # seconds before temporary messages by the bot get cleaned up, configurable?

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -63,6 +63,7 @@ class Server(Base):
     tags_enabled = Column(Boolean, nullable=False, server_default=true())
     create_voice = Column(Boolean, nullable=False, server_default=false())
     smotd = Column(String(255))
+    voice_category_prefix = Column(String(40))
     games = relationship("Game", back_populates="server", uselist=True)
     channels = relationship("Channel", back_populates="server", uselist=True)
     auto_verify_channels = relationship(

--- a/src/spellbot/versions/versions/d7a58c7aaeec_add_custom_voice_category.py
+++ b/src/spellbot/versions/versions/d7a58c7aaeec_add_custom_voice_category.py
@@ -1,0 +1,27 @@
+"""Add custom voice category
+
+Revision ID: d7a58c7aaeec
+Revises: bef35ca63436
+Create Date: 2021-01-28 11:31:02.043758
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d7a58c7aaeec"
+down_revision = "bef35ca63436"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("servers") as b:
+        b.add_column(
+            sa.Column("voice_category_prefix", sa.String(length=40), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("servers") as b:
+        b.drop_column("voice_category_prefix")

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -14,6 +14,7 @@
 > * `toggle-verify`: Toggles user verification on/off for a specific channel.
 > * `auto-verify <list|all>`: Set the channels that trigger user auto verification.
 > * `verify-message <your message>`: Set the verification message for this channel.
+> * `voice-category <string>`: Set category for voice channels created by !game.
 > * `stats`: Gets some statistics about SpellBot usage on your server.
 > * `help`: Get detailed usage help for SpellBot.
 
@@ -27,4 +28,3 @@
 > * Optional: Add tags by using `~tag-name` for the tags you want.
 
 `!export`
->  Exports historical game data to a CSV file. _Requires the "SpellBot Admin" role._

--- a/tests/snapshots/test_on_message_spellbot_help_2.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_2.txt
@@ -1,4 +1,6 @@
-> `!event <column 1> <column 2> ... [~tag-1 ~tag-2 ...] [msg: An optional message!]`
+> >  Exports historical game data to a CSV file. _Requires the "SpellBot Admin" role._
+
+`!event <column 1> <column 2> ... [~tag-1 ~tag-2 ...] [msg: An optional message!]`
 >  Create many games in batch from an attached CSV data file. _Requires the "SpellBot Admin" role._
 > 
 > For example, if your event is for a Modern tournement you might attach a CSV file with a comment like `!event Player1Username Player2Username`. This would assume that the players' discord user names are found in the "Player1Username" and "Player2Username" CSV columns. The game size is deduced from the number of column names given, so we know the games created in this example are `size:2`.


### PR DESCRIPTION
**Description**

Adds automatic voice channel creation via the admin-only `!game` command if voice channels is turned on for the server. These voice channels will get put into the default category channel. Or you can use the `!spellbot voice-category whatever` command to set the category prefix that should be used instead.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
