### PR TITLE
Allow channel specific tags enabled override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added ability to mention specific channels in `!spellbot tags` command to
+  allow overrides for specific channels.
+
 ## [v5.17.1](https://github.com/lexicalunit/spellbot/releases/tag/v5.17.1) - 2021-02-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ These commands will help you configure SpellBot for your server.
   - `teams`: Sets the teams available on this server.
   - `power`: Turns the power command on or off for this server.
   - `voice`: When on, SpellBot will automatically create voice channels.
-  - `tags`: Turn on or off the ability to use tags on your server.
+  - `tags`: Turn on or off the ability to use tags. Optionally mention specific channels.
   - `smotd`: Set the server message of the day.
   - `cmotd`: Set the message of the day for the channel where you run it.
   - `motd`: Set the privacy level for messages of the day.

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,7 +78,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
                     <li><code>teams</code>: Sets the teams available on this server.</li>
                     <li><code>power</code>: Turns the power command on or off for this server.</li>
                     <li><code>voice</code>: When on, SpellBot will automatically create voice channels.</li>
-                    <li><code>tags</code>: Turn on or off the ability to use tags on your server.</li>
+                    <li><code>tags</code>: Turn on or off the ability to use tags. Optionally mention specific channels.</li>
                     <li><code>smotd</code>: Set the server message of the day.</li>
                     <li><code>cmotd</code>: Set the message of the day for the channel where you run it.</li>
                     <li><code>motd</code>: Set the privacy level for messages of the day.</li>

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -125,8 +125,9 @@ spellbot_smotd: 'Right on, $reply. The server message of the day is now: $motd'
 spellbot_smotd_too_long: Sorry $reply, but that message is too long.
 spellbot_spectate: Ok $reply, I've turned the show spectator link setting $setting.
 spellbot_spectate_bad: Sorry $reply, but please provide an "on" or "off" setting.
-spellbot_tags: Ok $reply, I've turned the ability to use tags $setting.
-spellbot_tags_bad: Sorry $reply, but please provide an "on" or "off" setting.
+spellbot_tags_channels: 'Ok $reply, I''ve turned the ability to use tags $setting
+  for the channels: $channels.'
+spellbot_tags_server: Ok $reply, I've turned the ability to use tags $setting.
 spellbot_teams_none: Sorry $reply, but please provide a list of team names or `none`
   to erase teams.
 spellbot_teams_too_few: Sorry $reply, but please give at least two team names or `none`

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -220,6 +220,7 @@ class ChannelSettings(Base):
     require_verification = Column(Boolean, nullable=False, server_default=false())
     cmotd = Column(String(255))
     verify_message = Column(String(255))
+    tags_enabled = Column(Boolean, nullable=True)  # allow override on the server setting
     server = relationship("Server", back_populates="channel_settings")
 
 

--- a/src/spellbot/operations.py
+++ b/src/spellbot/operations.py
@@ -17,6 +17,14 @@ ChannelType = Union[
     discord.VoiceChannel,
 ]
 
+MentionableChannelType = Union[
+    discord.CategoryChannel,
+    discord.GroupChannel,
+    discord.StoreChannel,
+    discord.TextChannel,
+    discord.VoiceChannel,
+]
+
 
 def _user_or_guild_log_part(message: discord.Message) -> str:  # pragma: no cover
     if hasattr(message, "guild"):

--- a/src/spellbot/versions/versions/42ab4d026574_allow_tags_for_specific_channels.py
+++ b/src/spellbot/versions/versions/42ab4d026574_allow_tags_for_specific_channels.py
@@ -1,0 +1,25 @@
+"""Allow tags for specific channels
+
+Revision ID: 42ab4d026574
+Revises: d7a58c7aaeec
+Create Date: 2021-02-19 10:34:07.039733
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "42ab4d026574"
+down_revision = "d7a58c7aaeec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("channel_settings") as b:
+        b.add_column(sa.Column("tags_enabled", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("channel_settings") as b:
+        b.drop_column("tags_enabled")

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -345,11 +345,20 @@ class MockDM(MockChannel):
 
 
 class MockMessage:
-    def __init__(self, author, channel, content, mentions=None, attachments=None):
+    def __init__(
+        self,
+        author,
+        channel,
+        content,
+        mentions=None,
+        channel_mentions=None,
+        attachments=None,
+    ):
         self.author = author
         self.channel = channel
         self.content = content
         self.mentions = mentions or []
+        self.channel_mentions = channel_mentions or []
         self.attachments = attachments or []
         self.reactions = set()
         if isinstance(channel, MockDM):

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -6,7 +6,7 @@
 > * `teams <list|none>`: Sets the teams available on this server.
 > * `power <on|off>`: Turns the power command on or off for this server.
 > * `voice <on|off>`: When on, SpellBot will automatically create voice channels.
-> * `tags <on|off>`: Turn on or off the ability to use tags on your server.
+> * `tags [channels] <on|off>`: Turn on or off the ability to use tags.
 > * `smotd <your message>`: Set the server message of the day.
 > * `cmotd <your message>`: Set the message of the day for a channel.
 > * `motd <private|public|both>`: Set the visibility of MOTD in game posts.


### PR DESCRIPTION
**Description**

Allows admins to mention channels in the `!spellbot tags` command to override the setting for specific channels regardless of whatever the server setting is set to.

**Server level setting:**
![Screen Shot 2021-02-19 at 11 32 54 AM](https://user-images.githubusercontent.com/1903876/108552492-3be60500-72a6-11eb-905e-2e55329d37a5.png)

**Channel level setting:**
![Screen Shot 2021-02-19 at 11 32 13 AM](https://user-images.githubusercontent.com/1903876/108552525-486a5d80-72a6-11eb-963c-60b183d0e337.png)

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
