### PR TITLE
Adds the !spellbot queue-time command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a new `!spellbot queue-time` command that allows admins to enable/disable
+  average queue time details for the server or for specifically mentioned channels.
+
 ## [v5.18.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.18.0) - 2021-02-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ These commands will help you configure SpellBot for your server.
   - `power`: Turns the power command on or off for this server.
   - `voice`: When on, SpellBot will automatically create voice channels.
   - `tags`: Turn on or off the ability to use tags. Optionally mention specific channels.
+  - `queue-time`: Turn on or off average queue time details. Optionally mention specific channels.
   - `smotd`: Set the server message of the day.
   - `cmotd`: Set the message of the day for the channel where you run it.
   - `motd`: Set the privacy level for messages of the day.

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,6 +79,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
                     <li><code>power</code>: Turns the power command on or off for this server.</li>
                     <li><code>voice</code>: When on, SpellBot will automatically create voice channels.</li>
                     <li><code>tags</code>: Turn on or off the ability to use tags. Optionally mention specific channels.</li>
+                    <li><code>queue-time</code>: Turn on or off average queue time details. Optionally mention specific channels.</li>
                     <li><code>smotd</code>: Set the server message of the day.</li>
                     <li><code>cmotd</code>: Set the message of the day for the channel where you run it.</li>
                     <li><code>motd</code>: Set the privacy level for messages of the day.</li>

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -117,6 +117,9 @@ spellbot_power_bad: Sorry $reply, but please provide an "on" or "off" setting.
 spellbot_prefix: Ok $reply, I will now use "$prefix" as my command prefix on this
   server.
 spellbot_prefix_none: Sorry $reply, but please provide a prefix string.
+spellbot_queue_time_channels: 'Ok $reply, I''ve turned average queue time details
+  $setting for the channels: $channels.'
+spellbot_queue_time_server: Ok $reply, I've turned average queue time details $setting.
 spellbot_size: Ok $reply, the default game size for this channel has been set to $default_size
   players.
 spellbot_size_bad: Sorry $reply, but default game size should be between 2 and 4 players.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -61,6 +61,7 @@ class Server(Base):
     motd = Column(String(10), nullable=False, server_default=text("'both'"))
     power_enabled = Column(Boolean, nullable=False, server_default=true())
     tags_enabled = Column(Boolean, nullable=False, server_default=true())
+    queue_time_enabled = Column(Boolean, nullable=False, server_default=true())
     create_voice = Column(Boolean, nullable=False, server_default=false())
     smotd = Column(String(255))
     voice_category_prefix = Column(String(40))
@@ -220,7 +221,8 @@ class ChannelSettings(Base):
     require_verification = Column(Boolean, nullable=False, server_default=false())
     cmotd = Column(String(255))
     verify_message = Column(String(255))
-    tags_enabled = Column(Boolean, nullable=True)  # allow override on the server setting
+    tags_enabled = Column(Boolean, nullable=True)  # overrides server setting
+    queue_time_enabled = Column(Boolean, nullable=True)  # overrides server setting
     server = relationship("Server", back_populates="channel_settings")
 
 

--- a/src/spellbot/versions/versions/bf9689a382b3_allow_enable_disable_average_queue_times.py
+++ b/src/spellbot/versions/versions/bf9689a382b3_allow_enable_disable_average_queue_times.py
@@ -1,0 +1,36 @@
+"""Allow enable/disable average queue times
+
+Revision ID: bf9689a382b3
+Revises: 42ab4d026574
+Create Date: 2021-02-19 12:41:02.393856
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bf9689a382b3"
+down_revision = "42ab4d026574"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("channel_settings") as b:
+        b.add_column(sa.Column("queue_time_enabled", sa.Boolean(), nullable=True))
+    with op.batch_alter_table("servers") as b:
+        b.add_column(
+            sa.Column(
+                "queue_time_enabled",
+                sa.Boolean(),
+                server_default=sa.true(),
+                nullable=False,
+            ),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("servers") as b:
+        b.drop_column("queue_time_enabled")
+    with op.batch_alter_table("channel_settings") as b:
+        b.drop_column("queue_time_enabled")

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -7,6 +7,7 @@
 > * `power <on|off>`: Turns the power command on or off for this server.
 > * `voice <on|off>`: When on, SpellBot will automatically create voice channels.
 > * `tags [channels] <on|off>`: Turn on or off the ability to use tags.
+> * `queue-time [channels] <on|off>`: Turn on or off average queue time details.
 > * `smotd <your message>`: Set the server message of the day.
 > * `cmotd <your message>`: Set the message of the day for a channel.
 > * `motd <private|public|both>`: Set the visibility of MOTD in game posts.
@@ -25,6 +26,3 @@
 > * The user who issues this command is **NOT** added to the game themselves.
 > * You must mention all of the players to be seated in the game.
 > * Optional: Add a message by using `msg:` followed by the message content.
-> * Optional: Add tags by using `~tag-name` for the tags you want.
-
-`!export`

--- a/tests/snapshots/test_on_message_spellbot_help_2.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_2.txt
@@ -1,4 +1,7 @@
-> >  Exports historical game data to a CSV file. _Requires the "SpellBot Admin" role._
+> > * Optional: Add tags by using `~tag-name` for the tags you want.
+
+`!export`
+>  Exports historical game data to a CSV file. _Requires the "SpellBot Admin" role._
 
 `!event <column 1> <column 2> ... [~tag-1 ~tag-2 ...] [msg: An optional message!]`
 >  Create many games in batch from an attached CSV data file. _Requires the "SpellBot Admin" role._


### PR DESCRIPTION
**Description**

Adds a new `!spellbot queue-time` command that works exactly like the `!spellbot tags` command does. This new command allows you to enable or disable average queue time wait details.

**Usage at the server level:**
![Screen Shot 2021-02-19 at 1 35 54 PM](https://user-images.githubusercontent.com/1903876/108564255-ac495200-72b7-11eb-9798-ad75c1c9e4ed.png)

**Usage at the channel level:**
![Screen Shot 2021-02-19 at 1 36 34 PM](https://user-images.githubusercontent.com/1903876/108564248-a8b5cb00-72b7-11eb-8084-c4460f8e614a.png)

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
