### PR TITLE
Adds watch and unwatch commands for moderators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added new `!watch` and `!unwatch` commands that allows moderators to set up
+  notifications for when a player enters a new game on their server.
+
 ## [v5.19.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.19.0) - 2021-02-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ These commands will help you configure SpellBot for your server.
   - `help`: Get detailed usage help for SpellBot.
 - `!verify`: Allows moderators to verify a user on their server.
 - `!unverify`: Un-verifies a user for this server.
+- `!watch`: Allows moderators to watch a user on their server.
+- `!unwatch`: Un-watches a user for this server.
 
 ### 🛋️ Ergonomics
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,6 +94,8 @@ description: "SpellBot is the Discord bot that helps you find other players look
             </li>
             <li><code>!verify</code>: Allows moderators to verify a user on their server.</li>
             <li><code>!unverify</code>: Un-verifies a user for this server.</li>
+            <li><code>!watch</code>: Allows moderators to watch a user on their server.</li>
+            <li><code>!unwatch</code>: Un-watches a user for this server.</li>
         </ul>
     </section>
     <section id="ergonomics" class="level3">

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -156,3 +156,5 @@ unblock: 'Ok $reply, I have unblocked the following users for you: $unblocked'
 unblock_mentions: Sorry $reply, please do not mention users, just copy their name
   without an @.
 unblock_no_params: Sorry $reply, please say who you want to unblock with that command.
+watched_user_notification: 'Watched users ($users) just hopped into game $game_id.
+  Go to post: $link'

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -373,6 +373,22 @@ class UserServerSettings(Base):
     verified = Column(Boolean, nullable=True, server_default=false())
 
 
+class WatchedUser(Base):
+    __tablename__ = "watched_users"
+    user_xid = Column(
+        BigInteger,
+        ForeignKey("users.xid", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    guild_xid = Column(
+        BigInteger,
+        ForeignKey("servers.guild_xid", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+
+
 class UserPoints(Base):
     __tablename__ = "user_points"
     user_xid = Column(

--- a/src/spellbot/versions/versions/253d7fc50dcc_add_commands_to_watch_and_unwatch_users.py
+++ b/src/spellbot/versions/versions/253d7fc50dcc_add_commands_to_watch_and_unwatch_users.py
@@ -1,0 +1,30 @@
+"""Add commands to watch and unwatch users
+
+Revision ID: 253d7fc50dcc
+Revises: bf9689a382b3
+Create Date: 2021-02-19 14:27:35.586190
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "253d7fc50dcc"
+down_revision = "bf9689a382b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "watched_users",
+        sa.Column("user_xid", sa.BigInteger(), nullable=False),
+        sa.Column("guild_xid", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["guild_xid"], ["servers.guild_xid"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_xid"], ["users.xid"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_xid", "guild_xid"),
+    )
+
+
+def downgrade():
+    op.drop_table("watched_users")

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -115,6 +115,9 @@ class MockMember:
         self.owner = owner
         self.avatar = None
 
+        for role in roles:
+            role.members.add(self)
+
         # sent is a spy for tracking calls to send(), it doesn't exist on the real object.
         # There are also helpers for inspecting calls to sent defined on this class of
         # the form `last_sent_XXX` and `all_sent_XXX` to make our lives easier.
@@ -190,8 +193,9 @@ class MockMember:
 
 
 class MockRole:
-    def __init__(self, name):
+    def __init__(self, name, members=None):
         self.name = name
+        self.members = set(members or [])
 
 
 def create_voice_channel_side_effect(*args, **kwargs):
@@ -223,6 +227,7 @@ class MockGuild:
         self.categories = []
         self.owner_id = 0
         self.me = MockMember("bot", 0, [], True, True)
+        self.roles = []
 
         self.create_voice_channel = AsyncMock(
             side_effect=create_voice_channel_side_effect

--- a/tests/mocks/users.py
+++ b/tests/mocks/users.py
@@ -6,14 +6,17 @@ CLIENT_USER = "ADMIN"
 CLIENT_USER_ID = 82226367030108160
 
 ADMIN_ROLE = MockRole("SpellBot Admin")
-PLAYER_ROLE = MockRole("Player Player")
+MODERATORS_ROLE = MockRole("Moderators")
+PLAYER_ROLE = MockRole("Player")
 
 ADMIN = MockMember(CLIENT_USER, CLIENT_USER_ID, roles=[ADMIN_ROLE], admin=True)
 OWNER = MockMember(CLIENT_USER, CLIENT_USER_ID, roles=[], owner=True)
 FRIEND = MockMember("friend", 82169952898900001, roles=[PLAYER_ROLE])
-BUDDY = MockMember("buddy", 82942320688700002, roles=[ADMIN_ROLE, PLAYER_ROLE])
+BUDDY = MockMember(
+    "buddy", 82942320688700002, roles=[ADMIN_ROLE, PLAYER_ROLE, MODERATORS_ROLE]
+)
 GUY = MockMember("guy", 82988021019800003)
-DUDE = MockMember("dude", 82988761019800004, roles=[ADMIN_ROLE])
+DUDE = MockMember("dude", 82988761019800004, roles=[ADMIN_ROLE, MODERATORS_ROLE])
 
 JR = MockMember("J.R.", 72988021019800005)
 ADAM = MockMember("Adam", 62988021019800006)

--- a/tests/snapshots/test_on_message_spellbot_help_0.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_0.txt
@@ -41,8 +41,14 @@
 
 **### Commands for Admins ###**
 
+`!watch`
+>  Watch a user on your server.
+
 `!verify`
 >  Verify a user on your server.
+
+`!unwatch`
+>  Unwatch a user on your server.
 
 `!unverify`
 >  Unverify a user on your server.
@@ -51,4 +57,3 @@
 >  Configure SpellBot for your server. _Requires the "SpellBot Admin" role._
 > 
 > The following subcommands are supported:
-> * `config`: Just show the current configuration for this server.

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -1,3 +1,4 @@
+> * `config`: Just show the current configuration for this server.
 > * `channels <list>`: Set SpellBot to only respond in the given list of channels.
 > * `prefix <string>`: Set SpellBot's command prefix for text channels.
 > * `links <private|public>`: Set the privacy for generated SpellTable links.
@@ -25,4 +26,3 @@
 > Allows event runners to spin up an ad-hoc game directly between mentioned players.
 > * The user who issues this command is **NOT** added to the game themselves.
 > * You must mention all of the players to be seated in the game.
-> * Optional: Add a message by using `msg:` followed by the message content.

--- a/tests/snapshots/test_on_message_spellbot_help_2.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_2.txt
@@ -1,4 +1,5 @@
-> > * Optional: Add tags by using `~tag-name` for the tags you want.
+> > * Optional: Add a message by using `msg:` followed by the message content.
+> * Optional: Add tags by using `~tag-name` for the tags you want.
 
 `!export`
 >  Exports historical game data to a CSV file. _Requires the "SpellBot Admin" role._


### PR DESCRIPTION
**Description**

Allows any users with the role `SpellBot Admin` to run the following two commands:

- `!watch @player`
- `!unwatch @player`

After a player is set as watched, whenever they enter into a game, the `@Moderators` role will get a DM from the bot.

**Setting up the watch:**
![watch](https://user-images.githubusercontent.com/1903876/108571679-8cb92600-72c5-11eb-80bb-c242cac66aa7.png)

**Then, later, the watched user creates a game using `!lfg`:**
![lfg](https://user-images.githubusercontent.com/1903876/108571696-9cd10580-72c5-11eb-8963-cabbf2ce46a6.png)

**Moderators will get a notification from the bot:**
![notif](https://user-images.githubusercontent.com/1903876/108571712-abb7b800-72c5-11eb-8bfc-7f0fb6e1f22b.png)


For now the people that get notified are those with the `@Moderators` role. In the future this could be made configurable but for now it's not 🤷‍♀️ 

- Resolves #371

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
