### PR TITLE
Adds permissions error detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added permissions error detection to the output of `!spellbot config`.
+
 ## [v5.23.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.23.0) - 2021-02-25
 
 ### Added
@@ -364,7 +368,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Use is_() and isnot() to avoid spurious CodeFactor warnings.
+- Use is\_() and isnot() to avoid spurious CodeFactor warnings.
 
 ### Added
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -16,14 +16,13 @@ run() {
     return $?
 }
 
-
 if echo "$*" | grep -Eq -- '--help\b|-h\b' || [[ -z $1 ]]; then
     usage
 fi
 
 KIND="$1"
 
-if [[ "$KIND" != "major" && "$KIND" != "minor" && "$KIND" != "patch" ]]; then
+if [[ $KIND != "major" && $KIND != "minor" && $KIND != "patch" ]]; then
     usage
 fi
 
@@ -35,7 +34,7 @@ if [[ $BRANCH != "master" ]]; then
 fi
 
 CHANGES="$(git status -su)"
-if [[ -n "$CHANGES" ]]; then
+if [[ -n $CHANGES ]]; then
     echo "error: can not publish when there are uncomitted changes" 1>&2
     exit 1
 fi
@@ -44,10 +43,11 @@ fi
 run "poetry version '$KIND'"
 
 # run tests to ensure the build is good
-run "tox"
+# This is valuable, but let's lean on CI instead.
+# run "tox"
 
 # fetch the version from pyproject.toml
-VERSION="$(grep "^version" < pyproject.toml | cut -d= -f2 | sed 's/"//g;s/ //g;s/^/v/;')"
+VERSION="$(grep "^version" <pyproject.toml | cut -d= -f2 | sed 's/"//g;s/ //g;s/^/v/;')"
 
 # promote unreleased changes in the changelog
 OLD_CHANGELOG="$REPO_ROOT/CHANGELOG.md"
@@ -65,15 +65,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 EOF
 
 BODY_STARTED="false"
-while IFS= read -r line
-do
-    if [[ "$BODY_STARTED" == "false" ]]; then
+while IFS= read -r line; do
+    if [[ $BODY_STARTED == "false" ]]; then
         if [[ $line == *"[Unreleased]"* ]]; then
             BODY_STARTED="true"
-            echo "## [$VERSION](https://github.com/lexicalunit/spellbot/releases/tag/$VERSION) - $(date +'%Y-%m-%d')" >> "$NEW_CHANGELOG"
+            echo "## [$VERSION](https://github.com/lexicalunit/spellbot/releases/tag/$VERSION) - $(date +'%Y-%m-%d')" >>"$NEW_CHANGELOG"
         fi
     else
-        echo "$line" >> "$NEW_CHANGELOG"
+        echo "$line" >>"$NEW_CHANGELOG"
     fi
 done <"$OLD_CHANGELOG"
 run "mv '$NEW_CHANGELOG' '$OLD_CHANGELOG'"

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -156,5 +156,11 @@ unblock: 'Ok $reply, I have unblocked the following users for you: $unblocked'
 unblock_mentions: Sorry $reply, please do not mention users, just copy their name
   without an @.
 unblock_no_params: Sorry $reply, please say who you want to unblock with that command.
+warning_permissions_no_add_reactions: Warning! I do not have permissions to react
+  to messages in $channel.
+warning_permissions_no_manage_messages: Warning! I do not have permissions to manage
+  messages in $channel.
+warning_permissions_no_read_messages: Warning! I do not have permissions to read messages
+  in $channel.
 watched_user_notification: 'Watched users just hopped into game $game_id: $users.
   Go to post: $link'

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -136,6 +136,9 @@ class MockMember:
             def __init__(self, administrator):
                 self.administrator = administrator
                 self.value = 268528731
+                self.read_messages = True
+                self.add_reactions = True
+                self.manage_messages = True
 
         return MockPermissions(self.admin)
 


### PR DESCRIPTION
**Description**

SpellBot will now detect errors in permissions configuration on a server when `!spellbot config` is run.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [x] Entire test suite passes
