### PR TITLE
Adds unverified-only channels support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds unverified-only channels for use by unverified users (and admins).
+- New command to set unverified-only channels is `!spellbot unverified-only`.
+
 ## [v5.24.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.24.0) - 2021-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These commands will help you configure SpellBot for your server.
   - `size`: Sets the default game size for a specific channel.
   - `toggle-verify`: Toggles requirement of verification for a specific channel.
   - `auto-verify`: Set the channels that will trigger user auto verification.
+  - `unverified-only`: Set the channels that are only for unverified users.
   - `verify-message`: Set the verification message for a specific channel.
   - `voice-category`: Set category for voice channels created by !game.
   - `stats`: Gets some statistics about SpellBot usage on your server.

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,6 +86,7 @@ description: "SpellBot is the Discord bot that helps you find other players look
                     <li><code>size</code>: Sets the default game size for a specific channel.</li>
                     <li><code>toggle-verify</code>: Toggles requirement of verification for a specific channel.</li>
                     <li><code>auto-verify</code>: Set the channels that will trigger user auto verification.</li>
+                    <li><code>unverified-only</code>: Set the channels that are only for unverified users.</li>
                     <li><code>verify-message</code>: Set the verification message for a specific channel.</li>
                     <li><code>voice-category</code>: Set category for voice channels created by !game.</li>
                     <li><code>stats</code>: Gets some statistics about SpellBot usage on your server.</li>

--- a/src/spellbot/assets/strings.yaml
+++ b/src/spellbot/assets/strings.yaml
@@ -137,6 +137,10 @@ spellbot_teams_too_few: Sorry $reply, but please give at least two team names or
   to erase teams.
 spellbot_toggle_verify: Ok $reply, verification is now $setting for this channel.
 spellbot_unknown_subcommand: Sorry $reply, but the subcommand "$command" is not recognized.
+spellbot_unverified_only: 'Ok $reply, I will now only allow unverified users within:
+  $channels'
+spellbot_unverified_only_warn: 'Sorry $reply, but "$param" is not a valid channel.
+  Try using # to mention the channels you want.'
 spellbot_verify_message: 'Right on, $reply. The verification message for this channel
   is now: $msg'
 spellbot_verify_message_too_long: Sorry $reply, but that message is too long.

--- a/src/spellbot/data.py
+++ b/src/spellbot/data.py
@@ -70,6 +70,9 @@ class Server(Base):
     auto_verify_channels = relationship(
         "AutoVerifyChannel", back_populates="server", uselist=True
     )
+    unverified_only_channels = relationship(
+        "UnverifiedOnlyChannel", back_populates="server", uselist=True
+    )
     channel_settings = relationship(
         "ChannelSettings", back_populates="server", uselist=True, lazy="dynamic"
     )
@@ -203,6 +206,18 @@ class AutoVerifyChannel(Base):
         index=True,
     )
     server = relationship("Server", back_populates="auto_verify_channels")
+
+
+class UnverifiedOnlyChannel(Base):
+    __tablename__ = "unverified_only_channels"
+    channel_xid = Column(BigInteger, primary_key=True, nullable=False)
+    guild_xid = Column(
+        BigInteger,
+        ForeignKey("servers.guild_xid", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    server = relationship("Server", back_populates="unverified_only_channels")
 
 
 class ChannelSettings(Base):

--- a/src/spellbot/versions/versions/bbab2640b23b_adds_unferified_only_channels.py
+++ b/src/spellbot/versions/versions/bbab2640b23b_adds_unferified_only_channels.py
@@ -1,0 +1,39 @@
+"""Adds unferified-only channels
+
+Revision ID: bbab2640b23b
+Revises: 83c728a2823e
+Create Date: 2021-03-06 14:14:02.709635
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bbab2640b23b"
+down_revision = "83c728a2823e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "unverified_only_channels",
+        sa.Column("channel_xid", sa.BigInteger(), nullable=False),
+        sa.Column("guild_xid", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["guild_xid"], ["servers.guild_xid"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("channel_xid"),
+    )
+    op.create_index(
+        op.f("ix_unverified_only_channels_guild_xid"),
+        "unverified_only_channels",
+        ["guild_xid"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_unverified_only_channels_guild_xid"),
+        table_name="unverified_only_channels",
+    )
+    op.drop_table("unverified_only_channels")

--- a/tests/snapshots/test_on_message_spellbot_help_1.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_1.txt
@@ -15,6 +15,7 @@
 > * `size <integer>`: Sets the default game size for a specific channel.
 > * `toggle-verify`: Toggles user verification on/off for a specific channel.
 > * `auto-verify <list|all>`: Set the channels that trigger user auto verification.
+> * `unverified-only <list>`: Set the channels that are only for unverified users.
 > * `verify-message <your message>`: Set the verification message for this channel.
 > * `voice-category <string>`: Set category for voice channels created by !game.
 > * `stats`: Gets some statistics about SpellBot usage on your server.
@@ -25,4 +26,3 @@
 > 
 > Allows event runners to spin up an ad-hoc game directly between mentioned players.
 > * The user who issues this command is **NOT** added to the game themselves.
-> * You must mention all of the players to be seated in the game.

--- a/tests/snapshots/test_on_message_spellbot_help_2.txt
+++ b/tests/snapshots/test_on_message_spellbot_help_2.txt
@@ -1,4 +1,5 @@
-> > * Optional: Add a message by using `msg:` followed by the message content.
+> > * You must mention all of the players to be seated in the game.
+> * Optional: Add a message by using `msg:` followed by the message content.
 > * Optional: Add tags by using `~tag-name` for the tags you want.
 
 `!export`


### PR DESCRIPTION
**Description**

- Adds unverified-only channels for use by unverified users (and admins).
- New command to set unverified-only channels is `!spellbot unverified-only`.

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [ ] Entire test suite passes
