### PR TITLE
Fix for postgres uri scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround for SQLAlchemy 1.4.x which removed support for the postgres:// URI scheme.
+
 ## [v5.25.2](https://github.com/lexicalunit/spellbot/releases/tag/v5.25.2) - 2021-03-28
 
 ### Changed

--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -3681,6 +3681,9 @@ def main(
 
     database_env = get_db_env(database_env)
     database_url = get_db_url(database_env, database_url)
+    if database_url.startswith("postgres://"):
+        # SQLAlchemy 1.4.x removed support for the postgres:// URI scheme
+        database_url = database_url.replace("postgres://", "postgresql://", 1)
     port_env = get_port_env(port_env)
     port = get_port(port_env, port)
     host = get_host(host)


### PR DESCRIPTION
Workaround for SQLAlchemy 1.4.x which removed support for the postgres:// URI scheme.