### PR TITLE
Check read messages permissions on mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- When a user is mentioned, make sure they're allowed read messages in that channel.
+
 ## [v5.28.6](https://github.com/lexicalunit/spellbot/releases/tag/v5.28.6) - 2021-04-30
 
 ### Fixed

--- a/src/spellbot/__init__.py
+++ b/src/spellbot/__init__.py
@@ -1405,7 +1405,14 @@ class SpellBot(discord.Client):
             session, server, message.channel.id, message.channel.name
         )
         user = self.ensure_user_exists(session, message.author)
-        mentions = message.mentions if message.channel.type != "private" else []
+        mentions: List[discord.Member] = (
+            message.mentions if message.channel.type != "private" else []
+        )
+        mentions = [
+            mention
+            for mention in mentions
+            if message.channel.permissions_for(mention).read_messages
+        ]
 
         if user.waiting and user.game.channel_xid == message.channel.id:
             await self._call_attention_to_game(message, user.game)

--- a/tests/mocks/discord.py
+++ b/tests/mocks/discord.py
@@ -334,6 +334,13 @@ class MockTextChannel(MockChannel):
         self.members = members
         self.guild = MockGuild(500, "Guild Name", members)
 
+    def permissions_for(self, member):
+        class MockPermissions:
+            def __init__(self):
+                self.read_messages = True
+
+        return MockPermissions()
+
 
 class MockVoiceChannel(MockChannel):
     """Don't create this directly, use the channel_maker fixture instead."""


### PR DESCRIPTION
**Description**

SpellBot is supposed to operate within the channel where users are running commands. To that end, mentions users who do not have read messages permissions for that channel should not be able to be added to a game via mentions.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
