### PR TITLE
Handle deleted discord messages and channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Automatically delete games from deleted channels and messages.
+
 ## [v5.28.10](https://github.com/lexicalunit/spellbot/releases/tag/v5.28.10) - 2021-05-05
 
 ### Changed


### PR DESCRIPTION
Some jerks out there keep deleting discord messages or channels that contain SpellBot games in them for some reason. This eventually causes 404 API errors when the bot tries to check up on those games.

So I had to implement some code to watch for these delete events and handle them by deleting their associated games.
