### PR TITLE
More graceful handling of DM failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Slightly more graceful handling of send DM failure when our bot is blocked.
+
 ## [v5.29.0](https://github.com/lexicalunit/spellbot/releases/tag/v5.29.0) - 2021-05-06
 
 ### Added

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -456,7 +456,7 @@ class TestOperations:
 
         await safe_send_user(cast(discord.User, FRIEND), content="test")
 
-        assert "warning: discord (DM): could not send message to user" in caplog.text
+        assert "error: discord (DM): could not send message to user" in caplog.text
         assert "Internal Server Error" in caplog.text
 
     async def test_safe_send_user_clientuser(self, client, caplog):
@@ -481,8 +481,8 @@ class TestOperations:
 
         await safe_send_user(cast(discord.User, FRIEND), content="test")
 
-        assert "discord (DM): could not send message to user" in caplog.text
-        assert "Missing Permissions" in caplog.text
+        assert "warning: discord (DM): can not send messages to user" in caplog.text
+        assert "Missing Permissions" not in caplog.text
 
     async def test_safe_create_voice_channel(self, client, monkeypatch):
         mock_channel = MockTextChannel(1, "general", [])


### PR DESCRIPTION
**Description**

Slightly more graceful handling of DM failures (like when our bot is blocked or there's some reason we can't send to a particular user).

**Checklist**

- [x] Add tests for these changes
- [ ] Test coverage is not decreased
- [ ] Entire test suite passes
