### PR TITLE
Prefer no stateful Channel object in channels service

### DIFF
--- a/src/spellbot/client.py
+++ b/src/spellbot/client.py
@@ -158,8 +158,8 @@ class SpellBot(Bot):
         guilds = GuildsService()
         await guilds.upsert(message.guild)
         channels = ChannelsService()
-        await channels.upsert(message.channel)
-        if await channels.should_auto_verify():
+        channel_data = await channels.upsert(message.channel)
+        if channel_data["auto_verify"]:
             verified = True
         verify = VerifiesService()
         assert message.guild
@@ -167,9 +167,9 @@ class SpellBot(Bot):
         await verify.upsert(guild.id, message_author_xid, verified)
         if not user_can_moderate(message.author, guild, message.channel):
             user_is_verified = await verify.is_verified()
-            if user_is_verified and await channels.unverified_only():
+            if user_is_verified and channel_data["unverified_only"]:
                 await message.delete()
-            if not user_is_verified and await channels.verified_only():
+            if not user_is_verified and channel_data["verified_only"]:
                 await message.delete()
 
 

--- a/src/spellbot/interactions/__init__.py
+++ b/src/spellbot/interactions/__init__.py
@@ -43,6 +43,7 @@ class BaseInteraction:
     member: Optional[discord.Member]
     guild: Optional[discord.Guild]
     channel: Optional[discord.TextChannel]
+    channel_data: dict
 
     def __init__(self, bot: SpellBot, ctx: Optional[InteractionContext] = None):
         self.bot = bot
@@ -80,7 +81,9 @@ class BaseInteraction:
             try:
                 if ctx:
                     await interaction.services.guilds.upsert(interaction.guild)
-                    await interaction.services.channels.upsert(interaction.channel)
+                    interaction.channel_data = await interaction.services.channels.upsert(
+                        interaction.channel,
+                    )
                     await interaction.services.users.upsert(interaction.member)
                     if await interaction.services.users.is_banned(ctx.author_id):
                         raise UserBannedError()

--- a/src/spellbot/interactions/config_interaction.py
+++ b/src/spellbot/interactions/config_interaction.py
@@ -301,7 +301,7 @@ class ConfigInteraction(BaseInteraction):
 
     async def set_default_seats(self, seats: int):
         assert self.ctx
-        await self.services.channels.set_default_seats(seats)
+        await self.services.channels.set_default_seats(self.ctx.channel_id, seats)
         await safe_send_channel(
             self.ctx,
             f"Default seats set to {seats} for this channel.",
@@ -310,7 +310,7 @@ class ConfigInteraction(BaseInteraction):
 
     async def set_auto_verify(self, setting: bool):
         assert self.ctx
-        await self.services.channels.set_auto_verify(setting)
+        await self.services.channels.set_auto_verify(self.ctx.channel_id, setting)
         await safe_send_channel(
             self.ctx,
             f"Auto verification set to {setting} for this channel.",
@@ -319,7 +319,7 @@ class ConfigInteraction(BaseInteraction):
 
     async def set_verified_only(self, setting: bool):
         assert self.ctx
-        await self.services.channels.set_verified_only(setting)
+        await self.services.channels.set_verified_only(self.ctx.channel_id, setting)
         await safe_send_channel(
             self.ctx,
             f"Verified only set to {setting} for this channel.",
@@ -328,7 +328,7 @@ class ConfigInteraction(BaseInteraction):
 
     async def set_unverified_only(self, setting: bool):
         assert self.ctx
-        await self.services.channels.set_unverified_only(setting)
+        await self.services.channels.set_unverified_only(self.ctx.channel_id, setting)
         await safe_send_channel(
             self.ctx,
             f"Unverified only set to {setting} for this channel.",

--- a/src/spellbot/interactions/lfg_interaction.py
+++ b/src/spellbot/interactions/lfg_interaction.py
@@ -52,7 +52,7 @@ class LookingForGameInteraction(BaseInteraction):
         if format and not seats:
             seats = GameFormat(format).players
         else:
-            seats = seats or await self.services.channels.current_default_seats()
+            seats = seats or self.channel_data["default_seats"]
         format = format or GameFormat.COMMANDER.value  # type: ignore
         friend_xids = list(map(int, re.findall(r"<@!?(\d+)>", friends)))
 

--- a/tests/services/test_channels.py
+++ b/tests/services/test_channels.py
@@ -43,63 +43,65 @@ class TestServiceChannels:
 
     async def test_channels_current_default_seats(self, channel):
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        assert await channels.current_default_seats() == channel.default_seats
+        data = await channels.select(channel.xid)
+        assert data["default_seats"] == channel.default_seats
 
     async def test_channels_set_default_seats(self, channel):
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        assert await channels.current_default_seats() != 2
-        await channels.set_default_seats(2)
-        assert await channels.current_default_seats() == 2
+        data = await channels.select(channel.xid)
+        assert data["default_seats"] != 2
+
+        await channels.set_default_seats(channel.xid, 2)
+        data = await channels.select(channel.xid)
+        assert data["default_seats"] == 2
 
     async def test_channels_should_auto_verify(self, guild):
         channel = ChannelFactory.create(guild=guild, auto_verify=True)
         DatabaseSession.commit()
 
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        assert await channels.should_auto_verify()
+        data = await channels.select(channel.xid)
+        assert data["auto_verify"]
 
     async def test_channels_verified_only(self, guild):
         channel = ChannelFactory.create(guild=guild, verified_only=True)
         DatabaseSession.commit()
 
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        assert await channels.verified_only()
+        data = await channels.select(channel.xid)
+        assert data["verified_only"]
 
     async def test_channels_unverified_only(self, guild):
         channel = ChannelFactory.create(guild=guild, unverified_only=True)
         DatabaseSession.commit()
 
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        assert await channels.unverified_only()
+        data = await channels.select(channel.xid)
+        assert data["unverified_only"]
 
     async def test_channels_set_auto_verify(self, guild):
         channel = ChannelFactory.create(guild=guild, auto_verify=False)
         DatabaseSession.commit()
 
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        await channels.set_auto_verify(True)
-        assert await channels.should_auto_verify()
+        await channels.set_auto_verify(channel.xid, True)
+        data = await channels.select(channel.xid)
+        assert data["auto_verify"]
 
     async def test_channels_set_verified_only(self, guild):
         channel = ChannelFactory.create(guild=guild, verified_only=False)
         DatabaseSession.commit()
 
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        await channels.set_verified_only(True)
-        assert await channels.verified_only()
+        await channels.set_verified_only(channel.xid, True)
+        data = await channels.select(channel.xid)
+        assert data["verified_only"]
 
     async def test_channels_set_unverified_only(self, guild):
         channel = ChannelFactory.create(guild=guild, unverified_only=False)
         DatabaseSession.commit()
 
         channels = ChannelsService()
-        await channels.select(channel.xid)
-        await channels.set_unverified_only(True)
-        assert await channels.unverified_only()
+        await channels.set_unverified_only(channel.xid, True)
+        data = await channels.select(channel.xid)
+        assert data["unverified_only"]


### PR DESCRIPTION
Removes stateful `Channel` object from the `ChannelsService` class. This reduces the number of `await`s that go out to `@sync_to_async` functions. It's possible this is a style that should be adopted by all service classes.
