### PR TITLE
Adds a /set channel_motd command

### DIFF
--- a/src/spellbot/cogs/admin.py
+++ b/src/spellbot/cogs/admin.py
@@ -67,6 +67,23 @@ class AdminCog(commands.Cog):
         async with ConfigInteraction.create(self.bot, ctx) as interaction:
             await interaction.set_motd(message)
 
+    @cog_ext.cog_subcommand(
+        base="set",
+        name="channel_motd",
+        description="Set this channel's message of the day.",
+        options=[
+            {
+                "name": "message",
+                "required": True,
+                "description": "Message content",
+                "type": SlashCommandOptionType.STRING.value,
+            },
+        ],
+    )
+    async def channel_motd(self, ctx: SlashContext, message: str):
+        async with ConfigInteraction.create(self.bot, ctx) as interaction:
+            await interaction.set_channel_motd(message)
+
     @cog_ext.cog_slash(
         name="channels",
         description="Show the current configurations for channels on your server.",

--- a/src/spellbot/interactions/config_interaction.py
+++ b/src/spellbot/interactions/config_interaction.py
@@ -339,3 +339,12 @@ class ConfigInteraction(BaseInteraction):
             f"Unverified only set to {setting} for this channel.",
             hidden=True,
         )
+
+    async def set_channel_motd(self, message: str):
+        assert self.ctx
+        motd = await self.services.channels.set_motd(self.ctx.channel_id, message)
+        await safe_send_channel(
+            self.ctx,
+            f"Message of the day for this channel has been set to: {motd}",
+            hidden=True,
+        )

--- a/src/spellbot/models/channel.py
+++ b/src/spellbot/models/channel.py
@@ -105,4 +105,5 @@ class Channel(Base):
             "auto_verify": self.auto_verify,
             "unverified_only": self.unverified_only,
             "verified_only": self.verified_only,
+            "motd": self.motd,
         }

--- a/src/spellbot/services/channels.py
+++ b/src/spellbot/services/channels.py
@@ -67,3 +67,12 @@ class ChannelsService:
         query = update(Channel).where(Channel.xid == xid).values(unverified_only=setting)
         DatabaseSession.execute(query)
         DatabaseSession.commit()
+
+    @sync_to_async()
+    def set_motd(self, xid: int, message: str) -> str:
+        max_len = Channel.motd.property.columns[0].type.length  # type: ignore
+        motd = message[:max_len]
+        query = update(Channel).where(Channel.xid == xid).values(motd=motd)
+        DatabaseSession.execute(query)
+        DatabaseSession.commit()
+        return motd

--- a/tests/cogs/test_admin.py
+++ b/tests/cogs/test_admin.py
@@ -411,7 +411,6 @@ class TestCogAdminChannels(CogFixturesMixin):
         assert channel.auto_verify != default_value
 
     async def test_verified_only(self, ctx: InteractionContext):
-        ctx.send = AsyncMock()
         cog = AdminCog(self.bot)
         default_value = Channel.verified_only.default.arg  # type: ignore
         await cog.verified_only.func(cog, ctx, not default_value)
@@ -423,7 +422,6 @@ class TestCogAdminChannels(CogFixturesMixin):
         assert channel.verified_only != default_value
 
     async def test_unverified_only(self, ctx: InteractionContext):
-        ctx.send = AsyncMock()
         cog = AdminCog(self.bot)
         default_value = Channel.unverified_only.default.arg  # type: ignore
         await cog.unverified_only.func(cog, ctx, not default_value)
@@ -433,6 +431,17 @@ class TestCogAdminChannels(CogFixturesMixin):
         )
         channel = DatabaseSession.query(Channel).one()
         assert channel.unverified_only != default_value
+
+    async def test_channel_motd(self, ctx: InteractionContext):
+        cog = AdminCog(self.bot)
+        motd = "this is a channel message of the day"
+        await cog.channel_motd.func(cog, ctx, motd)
+        ctx.send.assert_called_once_with(
+            f"Message of the day for this channel has been set to: {motd}",
+            hidden=True,
+        )
+        channel = DatabaseSession.query(Channel).one()
+        assert channel.motd == motd
 
     async def test_channels(self, ctx: InteractionContext):
         assert ctx.guild

--- a/tests/factories/channel.py
+++ b/tests/factories/channel.py
@@ -6,6 +6,7 @@ from spellbot.models import Channel
 class ChannelFactory(factory.alchemy.SQLAlchemyModelFactory):
     xid = factory.Sequence(lambda n: 2000 + n)
     name = factory.Faker("color_name")
+    motd = factory.Faker("sentence")
 
     class Meta:
         model = Channel

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -16,4 +16,5 @@ class TestModelChannel:
             "auto_verify": channel.auto_verify,
             "unverified_only": channel.unverified_only,
             "verified_only": channel.verified_only,
+            "motd": channel.motd,
         }

--- a/tests/services/test_channels.py
+++ b/tests/services/test_channels.py
@@ -98,3 +98,14 @@ class TestServiceChannels:
         await channels.set_unverified_only(channel.xid, True)
         data = await channels.select(channel.xid)
         assert data["unverified_only"]
+
+    async def test_channels_set_motd(self, guild):
+        channels = ChannelsService()
+
+        channel = ChannelFactory.create(guild=guild, motd="whatever")
+        data = await channels.select(channel.xid)
+        assert data["motd"] == "whatever"
+
+        await channels.set_motd(channel.xid, "something else")
+        data = await channels.select(channel.xid)
+        assert data["motd"] == "something else"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -32,6 +32,7 @@ class TestSpellBot:
         }
         assert bot.slash.subcommands["set"].keys() == {
             "auto_verify",
+            "channel_motd",
             "default_seats",
             "motd",
             "unverified_only",


### PR DESCRIPTION
Adds the `/set channel_motd` command. These motd are not yet reflected in the content of games nor in the the response to the `/channels` command. That is future work that needs to be done.