### PR TITLE
Removes legacy prefix and slash command CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `!command` CTA to use slash commands and legacy prefix logic.
+
 ## [v7.5.2](https://github.com/lexicalunit/spellbot/releases/tag/v7.5.2) - 2021-11-23
 
 ### Changed

--- a/src/spellbot/cli.py
+++ b/src/spellbot/cli.py
@@ -36,6 +36,7 @@ uvloop.install()
     help="Development mode, automatically reload bot when source changes",
 )
 @click.option(
+    "-g",
     "--debug",
     default=False,
     is_flag=True,

--- a/src/spellbot/database.py
+++ b/src/spellbot/database.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import Session
 from wrapt import CallableObjectProxy
 
-from .models import Guild, create_all
+from .models import create_all
 
 logger = logging.getLogger(__name__)
 ProxiedObject = TypeVar("ProxiedObject")
@@ -143,11 +143,3 @@ def rollback_transaction():
     if not connection.closed:  # pragma: no cover
         connection.close()
     engine.dispose()
-
-
-@sync_to_async
-def get_legacy_prefixes() -> dict:  # pragma: no cover
-    return {
-        row[0]: row[1]
-        for row in DatabaseSession.query(Guild.xid, Guild.legacy_prefix).all()
-    }

--- a/src/spellbot/migrations/versions/6267f69c5dfd_remove_legacy_prefix.py
+++ b/src/spellbot/migrations/versions/6267f69c5dfd_remove_legacy_prefix.py
@@ -1,0 +1,32 @@
+"""Remove legacy prefix
+
+Revision ID: 6267f69c5dfd
+Revises: ee653a3075c6
+Create Date: 2021-11-25 20:23:35.556348
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6267f69c5dfd"
+down_revision = "ee653a3075c6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("guilds", "legacy_prefix")
+
+
+def downgrade():
+    op.add_column(
+        "guilds",
+        sa.Column(
+            "legacy_prefix",
+            sa.VARCHAR(length=10),
+            server_default=sa.text("'!'::character varying"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )

--- a/src/spellbot/models/guild.py
+++ b/src/spellbot/models/guild.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, String, false, text
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, String, false
 from sqlalchemy.orm import relationship
 
 from .base import Base, now
@@ -62,13 +62,6 @@ class Guild(Base):
         server_default=false(),
         doc="Configuration for showing points reporting on started games",
     )
-    legacy_prefix = Column(
-        String(10),
-        nullable=False,
-        default="!",
-        server_default=text("'!'"),
-        doc="Legacy command prefix used by this guild before v7",
-    )
 
     games = relationship(
         "Game",
@@ -100,7 +93,6 @@ class Guild(Base):
             "show_links": self.show_links,
             "voice_create": self.voice_create,
             "show_points": self.show_points,
-            "legacy_prefix": self.legacy_prefix,
             "channels": [channel.to_dict() for channel in self.channels],
             "awards": [award.to_dict() for award in self.awards],
         }

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -8,7 +8,7 @@
                                     LOG_LEVEL environment variable.
     -d, --dev                       Development mode, automatically reload bot
                                     when source changes
-    --debug                         Enable detailed asyncio debugging
+    -g, --debug                     Enable detailed asyncio debugging
     -m, --mock-games                Produce mock game urls instead of real ones
     -s, --sync-commands             Force sync all slash commands at startup
     -c, --clean-commands            Cleanup all unused slash commands at startup

--- a/tests/models/test_guild.py
+++ b/tests/models/test_guild.py
@@ -18,7 +18,6 @@ class TestModelGuild:
             "show_links": guild.show_links,
             "voice_create": guild.voice_create,
             "show_points": guild.show_points,
-            "legacy_prefix": guild.legacy_prefix,
             "channels": [channel1.to_dict(), channel2.to_dict()],
             "awards": [award1.to_dict(), award2.to_dict()],
         }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,10 @@ class TestCLI:
             mock_games=True,
         )
 
+    def test_run_bot_with_debug(self, cli, runner):
+        runner.invoke(main, ["--debug"])
+        cli.loop.set_debug.assert_called_once_with(True)
+
     def test_run_bot_with_dev(self, cli, runner):
         runner.invoke(main, ["--dev"])
         cli.hupper.start_reloader.assert_called_once_with("spellbot.main")


### PR DESCRIPTION
Removes the CTA to use slash commands when a user tries to use a message command with a legacy prefix.