### PR TITLE
Fewer fetch message calls, more metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add span context to each trace based on the discord interaction or message context.
 - Attempt to shrink the docker container image size a bit.
 - Break out the leave button and leave command traces.
+- Avoid API calls to fetch messages by using `discord.PartialMessage`.
+- Added detailed trace metrics for operations, lfg cog, and leave cog.
 
 ## [v7.10.4](https://github.com/lexicalunit/spellbot/releases/tag/v7.10.4) - 2021-12-12
 

--- a/src/spellbot/interactions/config_interaction.py
+++ b/src/spellbot/interactions/config_interaction.py
@@ -5,8 +5,8 @@ from discord_slash.context import InteractionContext
 
 from .. import SpellBot
 from ..operations import (
-    safe_fetch_message,
     safe_fetch_text_channel,
+    safe_get_partial_message,
     safe_send_channel,
     safe_update_embed,
 )
@@ -35,16 +35,14 @@ class ConfigInteraction(BaseInteraction):
             assert found
 
             data = await self.services.games.to_dict()
+            bot = self.bot
             guild_xid = self.ctx.guild_id
             channel_xid = data["channel_xid"]
             message_xid = data["message_xid"]
 
-            channel = await safe_fetch_text_channel(self.bot, guild_xid, channel_xid)
-            if not channel:
+            if not (chan := await safe_fetch_text_channel(bot, guild_xid, channel_xid)):
                 return
-
-            message = await safe_fetch_message(channel, guild_xid, message_xid)
-            if not message:
+            if not (message := safe_get_partial_message(chan, guild_xid, message_xid)):
                 return
 
             embed = await self.services.games.to_embed()

--- a/src/spellbot/interactions/task_interaction.py
+++ b/src/spellbot/interactions/task_interaction.py
@@ -11,8 +11,8 @@ from ..metrics import alert_error
 from ..operations import (
     bot_can_delete_channel,
     safe_delete_channel,
-    safe_fetch_message,
     safe_fetch_text_channel,
+    safe_get_partial_message,
     safe_update_embed,
 )
 from ..services import GamesService
@@ -152,8 +152,7 @@ class TaskInteraction(BaseInteraction):
         if not chan:
             return
 
-        post = await safe_fetch_message(chan, guild_xid, message_xid)
-        if not post:
+        if not (post := safe_get_partial_message(chan, guild_xid, message_xid)):
             return
 
         await safe_update_embed(

--- a/src/spellbot/metrics.py
+++ b/src/spellbot/metrics.py
@@ -55,7 +55,7 @@ def alert_error(
 
 
 @skip_if_no_metrics
-def add_span_context(ctx: Any):
+def add_span_context(ctx: Any):  # pragma: no cover
     span = tracer.current_span()
     for prop in CTX_PROPS:
         if value := getattr(ctx, prop, None):

--- a/tests/cogs/test_config_cog.py
+++ b/tests/cogs/test_config_cog.py
@@ -33,7 +33,7 @@ class TestCogConfigPowerLevelWhenUserWaiting(InteractionContextMixin):
 
         with mock_operations(config_interaction):
             config_interaction.safe_fetch_text_channel.return_value = self.ctx.channel
-            config_interaction.safe_fetch_message.return_value = self.ctx.message
+            config_interaction.safe_get_partial_message.return_value = self.ctx.message
 
             cog = ConfigCog(self.bot)
             await cog.power.func(cog, self.ctx, level=10)
@@ -81,7 +81,7 @@ class TestCogConfigPowerLevelWhenUserWaiting(InteractionContextMixin):
 
         with mock_operations(config_interaction):
             config_interaction.safe_fetch_text_channel.return_value = self.ctx.channel
-            config_interaction.safe_fetch_message.return_value = None
+            config_interaction.safe_get_partial_message.return_value = None
 
             cog = ConfigCog(self.bot)
             await cog.power.func(cog, self.ctx, level=10)

--- a/tests/cogs/test_leave_cog.py
+++ b/tests/cogs/test_leave_cog.py
@@ -15,7 +15,7 @@ class TestCogLeaveGame(InteractionContextMixin):
 
         with mock_operations(leave_interaction):
             leave_interaction.safe_fetch_text_channel.return_value = self.ctx.channel
-            leave_interaction.safe_fetch_message.return_value = self.ctx.message
+            leave_interaction.safe_get_partial_message.return_value = self.ctx.message
 
             cog = LeaveGameCog(self.bot)
             await cog.leave_command.func(cog, self.ctx)
@@ -47,7 +47,7 @@ class TestCogLeaveGame(InteractionContextMixin):
 
         with mock_operations(leave_interaction):
             leave_interaction.safe_fetch_text_channel.return_value = self.ctx.channel
-            leave_interaction.safe_fetch_message.return_value = self.ctx.message
+            leave_interaction.safe_get_partial_message.return_value = self.ctx.message
 
             cog = LeaveGameCog(self.bot)
             await cog.leave_command.func(cog, self.ctx)
@@ -91,7 +91,7 @@ class TestCogLeaveGame(InteractionContextMixin):
 
         with mock_operations(leave_interaction):
             leave_interaction.safe_fetch_text_channel.return_value = self.ctx.channel
-            leave_interaction.safe_fetch_message.return_value = None
+            leave_interaction.safe_get_partial_message.return_value = None
 
             cog = LeaveGameCog(self.bot)
             await cog.leave_command.func(cog, self.ctx)

--- a/tests/cogs/test_lfg_cog.py
+++ b/tests/cogs/test_lfg_cog.py
@@ -61,7 +61,7 @@ class TestCogLookingForGame(InteractionContextMixin):
         with mock_operations(lfg_interaction, users=[author_player, other_player]):
             message = MagicMock(spec=discord.Message)
             message.id = game.message_xid
-            lfg_interaction.safe_fetch_message.return_value = message
+            lfg_interaction.safe_get_partial_message.return_value = message
 
             cog = LookingForGameCog(self.bot)
             await cog.lfg.func(cog, self.ctx)
@@ -114,7 +114,7 @@ class TestCogLookingForGame(InteractionContextMixin):
         game = self.factories.game.create(guild=guild, channel=channel, message_xid=100)
 
         with mock_operations(lfg_interaction, users=[user, other]):
-            lfg_interaction.safe_fetch_message.return_value = None
+            lfg_interaction.safe_get_partial_message.return_value = None
 
             message = MagicMock(spec=discord.Message)
             message.id = game.message_xid + 1
@@ -334,7 +334,7 @@ class TestCogLookingForGameJoinButton(ComponentContextMixin):
         user = ctx_user(self.ctx)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author]):
-            lfg_interaction.safe_fetch_message.return_value = self.ctx.message
+            lfg_interaction.safe_get_partial_message.return_value = self.ctx.message
 
             cog = LookingForGameCog(self.bot)
             await cog.join.func(cog, self.ctx)
@@ -434,7 +434,7 @@ class TestCogLookingForGameJoinButton(ComponentContextMixin):
         ctx_game(self.ctx, guild, channel, status=GameStatus.STARTED.value)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author]):
-            lfg_interaction.safe_fetch_message.return_value = self.ctx.message
+            lfg_interaction.safe_get_partial_message.return_value = self.ctx.message
 
             cog = LookingForGameCog(self.bot)
             await cog.join.func(cog, self.ctx)
@@ -458,7 +458,7 @@ class TestCogLookingForGameJoinButton(ComponentContextMixin):
         ctx_game(self.ctx, guild, channel, status=GameStatus.STARTED.value)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author]):
-            lfg_interaction.safe_fetch_message.return_value = None
+            lfg_interaction.safe_get_partial_message.return_value = None
 
             cog = LookingForGameCog(self.bot)
             await cog.join.func(cog, self.ctx)
@@ -479,13 +479,13 @@ class TestCogLookingForGameJoinButton(ComponentContextMixin):
         user = ctx_user(self.ctx)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author]):
-            lfg_interaction.safe_fetch_message.return_value = self.ctx.message
+            lfg_interaction.safe_get_partial_message.return_value = self.ctx.message
             lfg_interaction.safe_update_embed_origin.return_value = False
 
             cog = LookingForGameCog(self.bot)
             await cog.join.func(cog, self.ctx)
 
-            mock_call = lfg_interaction.safe_update_embed
+            mock_call = lfg_interaction.safe_update_embed_origin
             assert mock_call.call_args_list[0].kwargs["embed"].to_dict() == {
                 "color": self.settings.EMBED_COLOR,
                 "description": (
@@ -742,7 +742,7 @@ class TestCogLookingForGameLeaveButton(ComponentContextMixin):
 
         with mock_operations(leave_interaction, users=[self.ctx.author]):
             leave_interaction.safe_fetch_text_channel.return_value = self.ctx.channel
-            leave_interaction.safe_fetch_message.return_value = self.ctx.message
+            leave_interaction.safe_get_partial_message.return_value = self.ctx.message
 
             cog = LookingForGameCog(self.bot)
             await cog.leave.func(cog, self.ctx)
@@ -775,7 +775,7 @@ class TestCogLookingForGameLeaveButton(ComponentContextMixin):
 
         with mock_operations(leave_interaction, users=[self.ctx.author]):
             leave_interaction.safe_fetch_text_channel.return_value = self.ctx.channel
-            leave_interaction.safe_fetch_message.return_value = self.ctx.message
+            leave_interaction.safe_get_partial_message.return_value = self.ctx.message
 
             cog = LookingForGameCog(self.bot)
             await cog.leave.func(cog, self.ctx)
@@ -800,7 +800,7 @@ class TestCogLookingForGameVoiceCreate(ComponentContextMixin):
         other_player = mock_discord_user(other_user)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author, other_player]):
-            lfg_interaction.safe_fetch_message.return_value = self.ctx.message
+            lfg_interaction.safe_get_partial_message.return_value = self.ctx.message
             voice_channel = build_voice_channel(self.ctx.guild)
             lfg_interaction.safe_create_voice_channel.return_value = voice_channel
             lfg_interaction.safe_create_invite.return_value = "http://invite"
@@ -822,7 +822,7 @@ class TestCogLookingForGameVoiceCreate(ComponentContextMixin):
         other_player = mock_discord_user(other_user)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author, other_player]):
-            lfg_interaction.safe_fetch_message.return_value = self.ctx.message
+            lfg_interaction.safe_get_partial_message.return_value = self.ctx.message
             lfg_interaction.safe_ensure_voice_category.return_value = None
 
             cog = LookingForGameCog(self.bot)
@@ -842,7 +842,7 @@ class TestCogLookingForGameVoiceCreate(ComponentContextMixin):
         other_player = mock_discord_user(other_user)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author, other_player]):
-            lfg_interaction.safe_fetch_message.return_value = self.ctx.message
+            lfg_interaction.safe_get_partial_message.return_value = self.ctx.message
             lfg_interaction.safe_create_voice_channel.return_value = None
 
             cog = LookingForGameCog(self.bot)
@@ -863,7 +863,7 @@ class TestCogLookingForGameVoiceCreate(ComponentContextMixin):
         other_player = mock_discord_user(other_user)
 
         with mock_operations(lfg_interaction, users=[self.ctx.author, other_player]):
-            lfg_interaction.safe_fetch_message.return_value = self.ctx.message
+            lfg_interaction.safe_get_partial_message.return_value = self.ctx.message
             voice_channel = build_voice_channel(self.ctx.guild)
             lfg_interaction.safe_create_voice_channel.return_value = voice_channel
             lfg_interaction.safe_create_invite.return_value = None

--- a/tests/interactions/test_task.py
+++ b/tests/interactions/test_task.py
@@ -103,7 +103,7 @@ class TestInteractionTaskExpireInactiveGames(BaseMixin):
                 task_interaction.safe_fetch_text_channel = AsyncMock(
                     return_value=discord_channel,
                 )
-                task_interaction.safe_fetch_message = AsyncMock(
+                task_interaction.safe_get_partial_message = MagicMock(
                     return_value=discord_message,
                 )
 
@@ -149,7 +149,7 @@ class TestInteractionTaskExpireInactiveGames(BaseMixin):
                 task_interaction.safe_fetch_text_channel = AsyncMock(
                     return_value=discord_channel,
                 )
-                task_interaction.safe_fetch_message = AsyncMock(return_value=None)
+                task_interaction.safe_get_partial_message = MagicMock(return_value=None)
 
                 await interaction.expire_inactive_games()
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -16,9 +16,9 @@ from spellbot.operations import (
     safe_delete_channel,
     safe_ensure_voice_category,
     safe_fetch_guild,
-    safe_fetch_message,
     safe_fetch_text_channel,
     safe_fetch_user,
+    safe_get_partial_message,
     safe_message_reply,
     safe_send_user,
     safe_update_embed,
@@ -77,7 +77,7 @@ class TestOperationsFetchTextChannel:
 
 
 @pytest.mark.asyncio
-class TestOperationsFetchMessage:
+class TestOperationsGetPartialMessage:
     read_perms = discord.Permissions(
         discord.Permissions.read_messages.flag
         | discord.Permissions.read_message_history.flag,
@@ -94,11 +94,11 @@ class TestOperationsFetchMessage:
         self.channel = dpy_channel
         self.author = dpy_author
         self.message = build_message(self.guild, self.channel, self.author)
-        self.channel.fetch_message = AsyncMock(return_value=self.message)
+        self.channel.get_partial_message = MagicMock(return_value=self.message)
 
     async def test_happy_path(self):
         self.channel.permissions_for = MagicMock(return_value=self.read_perms)
-        found = await safe_fetch_message(self.channel, self.guild.id, self.message.id)
+        found = safe_get_partial_message(self.channel, self.guild.id, self.message.id)
         assert found is self.message
 
     async def test_not_text(self):
@@ -106,11 +106,11 @@ class TestOperationsFetchMessage:
         channel.type = discord.ChannelType.voice
         channel.guild = self.guild
         channel.permissions_for = MagicMock(return_value=self.read_perms)
-        assert not await safe_fetch_message(channel, self.guild.id, self.message.id)
+        assert not safe_get_partial_message(channel, self.guild.id, self.message.id)
 
     async def test_no_permissions(self):
         self.channel.permissions_for = MagicMock(return_value=discord.Permissions())
-        assert not await safe_fetch_message(self.channel, self.guild.id, self.message.id)
+        assert not safe_get_partial_message(self.channel, self.guild.id, self.message.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Avoid API calls to fetch messages by using `discord.PartialMessage`.
- Added detailed trace metrics for operations, lfg cog, and leave cog.
