### PR TITLE
Adds bad user flagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Flag users as bad if we get a 403 when trying to send a DM to them.
+- Adds a lot more tracer tags for Discord operation functions.
+
 ## [v7.10.8](https://github.com/lexicalunit/spellbot/releases/tag/v7.10.8) - 2021-12-27
 
 ### Changed

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -259,10 +259,16 @@ class TestOperationsSendUser:
         exception = discord.errors.HTTPException(MagicMock(), "msg")
         setattr(exception, "code", CANT_SEND_CODE)
         user = MagicMock(spec=Union[discord.User, discord.Member])
+        user.id = 1234
         user.__str__ = lambda self: "user#1234"  # type: ignore
         user.send = AsyncMock(side_effect=exception)
         await safe_send_user(user, "content")
         assert "not allowed to send message to user#1234" in caplog.text
+
+        # user should now be on the "bad users" list
+        user.send = AsyncMock(side_effect=exception)
+        await safe_send_user(user, "content")
+        assert "not sending to bad user user#1234" in caplog.text
 
     async def test_http_failure(self, caplog):
         exception = discord.errors.HTTPException(MagicMock(), "msg")


### PR DESCRIPTION
When we get a 403 trying to send messages to a user, it means they've blocked us. We have no way of knowing that this is the case until we try to send to them. Too many 4xx errors may cause Discord to auto-flag SpellBot as spam. So when we see a 403 for a user send, add them to a list of "bad users" and don't try to send messages to them any more.