### PR TITLE
Trace discord service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Puts discord request metrics into their own service.
+- Add HTTP request path to resource name in dd trace for discord spans.
+- Capture DD_TRACE_ENABLED env var in settings an use to turn metrics on/off.
+
 ## [v7.10.10](https://github.com/lexicalunit/spellbot/releases/tag/v7.10.10) - 2021-12-27
 
 ### Added

--- a/src/spellbot/settings.py
+++ b/src/spellbot/settings.py
@@ -45,6 +45,7 @@ class Settings(metaclass=Singleton):  # pylint: disable=R0902
         # datadog
         self.DD_API_KEY = getenv("DD_API_KEY")
         self.DD_APP_KEY = getenv("DD_APP_KEY")
+        self.DD_TRACE_ENABLED = getenv("DD_TRACE_ENABLED", "true").lower() == "true"
 
         # database
         default_database_url = f"postgresql://postgres@{self.HOST}:5432/postgres"


### PR DESCRIPTION
### Added

- Puts discord request metrics into their own service.
- Add HTTP request path to resource name in dd trace for discord spans.
- Capture DD_TRACE_ENABLED env var in settings an use to turn metrics on/off.
