### PR TITLE
Ensure blocked players can't join games via friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensures that users who have blocked each other can not be added to a game via friends.
+
 ## [v7.11.0](https://github.com/lexicalunit/spellbot/releases/tag/v7.11.0) - 2021-12-31
 
 ### Added

--- a/src/spellbot/interactions/lfg_interaction.py
+++ b/src/spellbot/interactions/lfg_interaction.py
@@ -59,7 +59,7 @@ class LookingForGameInteraction(BaseInteraction):
         if friend_xids:
             friend_xids = await self.ensure_users_exist(friend_xids)
         if friend_xids:
-            friend_xids = await self.services.games.filter_blocked(
+            friend_xids = await self.services.games.filter_blocked_list(
                 self.ctx.author_id,
                 friend_xids,
             )

--- a/tests/services/test_games.py
+++ b/tests/services/test_games.py
@@ -214,7 +214,7 @@ class TestServiceGamesFilterBlocked:
 
         games = GamesService()
         await games.select(game.id)
-        assert await games.filter_blocked(user2.xid, [user1.xid]) == []
+        assert await games.filter_blocked_list(user2.xid, [user1.xid]) == []
 
     async def test_when_blocker_outside_game(self, game):
         user1 = UserFactory.create(game=game)
@@ -224,7 +224,7 @@ class TestServiceGamesFilterBlocked:
 
         games = GamesService()
         await games.select(game.id)
-        assert await games.filter_blocked(user2.xid, [user1.xid]) == []
+        assert await games.filter_blocked_list(user2.xid, [user1.xid]) == []
 
     async def test_when_no_blockers(self, game):
         UserFactory.create(game=game)
@@ -232,7 +232,7 @@ class TestServiceGamesFilterBlocked:
 
         games = GamesService()
         await games.select(game.id)
-        assert await games.filter_blocked(user3.xid, [1, 2, 3]) == [1, 2, 3]
+        assert await games.filter_blocked_list(user3.xid, [1, 2, 3]) == [1, 2, 3]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Ensures that blocking works in this case:

1. User A blocked user F.
2. User A starts a game.
3. User B runs `/lfg friends:@F`.

In this case, since user B wants to be in a game with user F, a new game should be spun up with users B and F in it. User A should remain in their game and user F should not be able to join that game under any circumstance.