### PR TITLE
Count plays per server for awards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure that plays counts for awards are only counted on a per-server basis.
+
 ### Changed
 
 - Updated outdated dependencies.

--- a/tests/services/test_awards.py
+++ b/tests/services/test_awards.py
@@ -26,6 +26,29 @@ class TestServiceAwards:
         give_outs = await awards.give_awards(guild_xid=guild.xid, player_xids=[user.xid])
         assert give_outs == {user.xid: NewAward(role="one", message="msg", remove=False)}
 
+    async def test_give_awards_when_plays_from_different_server(
+        self,
+        guild: Guild,
+        channel: Channel,
+        factories: Factories,
+    ):
+        user = factories.user.create()
+        factories.guild_award.create(guild=guild, count=1, role="one", message="msg")
+        factories.user_award.create(
+            user_xid=user.xid,
+            guild_xid=guild.xid,
+            guild_award_id=None,
+        )
+
+        other_guild = factories.guild.create(xid=guild.xid + 1)
+        other_channel = factories.channel.create(xid=channel.xid + 1, guild=other_guild)
+        other_game = factories.game.create(guild=other_guild, channel=other_channel)
+        factories.play.create(user_xid=user.xid, game_id=other_game.id)
+
+        awards = AwardsService()
+        give_outs = await awards.give_awards(guild_xid=guild.xid, player_xids=[user.xid])
+        assert give_outs == {}
+
     async def test_give_awards_no_plays(
         self,
         guild: Guild,


### PR DESCRIPTION
Ensures that counts for number of games played for the purpose of giving out guild awards only considers games played in that server.
