### PR TITLE
Adds dd ignore exceptions for user errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Do not treat user errors as error traces in datadog.
+
 ## [v7.12.2](https://github.com/lexicalunit/spellbot/releases/tag/v7.12.2) - 2022-02-20
 
 ### Fixed
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Updated outdated dependencies.
+- Do not send exception metrics about user errors.
 
 ## [v7.12.1](https://github.com/lexicalunit/spellbot/releases/tag/v7.12.1) - 2022-02-15
 

--- a/src/spellbot/client.py
+++ b/src/spellbot/client.py
@@ -20,7 +20,7 @@ from .errors import (
     UserUnverifiedError,
     UserVerifiedError,
 )
-from .metrics import add_span_error, setup_metrics
+from .metrics import add_span_error, setup_ignored_errors, setup_metrics
 from .operations import safe_send_user
 from .services import ChannelsService, GuildsService, VerifiesService
 from .settings import Settings
@@ -120,6 +120,7 @@ class SpellBot(Bot):
     @tracer.wrap(name="interaction", resource="on_message")
     async def on_message(self, message: discord.Message):
         span = tracer.current_span()
+        setup_ignored_errors(span)
 
         # handle DMs normally
         if not message.guild or not hasattr(message.guild, "id"):

--- a/src/spellbot/interactions/base_interaction.py
+++ b/src/spellbot/interactions/base_interaction.py
@@ -18,6 +18,7 @@ from ..errors import (
     UserUnverifiedError,
     UserVerifiedError,
 )
+from ..metrics import setup_ignored_errors
 from ..services import ServicesRegistry, VerifiesService
 from ..utils import user_can_moderate
 
@@ -104,7 +105,8 @@ class BaseInteraction:
         ctx: Optional[InteractionContext] = None,
     ) -> AsyncGenerator[InteractionType, None]:
         interaction = cls(bot, ctx) if ctx else cls(bot)
-        with tracer.trace(name=f"spellbot.interactions.{cls.__name__}.create"):
+        with tracer.trace(name=f"spellbot.interactions.{cls.__name__}.create") as span:
+            setup_ignored_errors(span)
             async with db_session_manager():
                 try:
                     await interaction.upsert_request_objects()

--- a/src/spellbot/metrics.py
+++ b/src/spellbot/metrics.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import re
 from functools import wraps
 from typing import Any, Callable, Optional
@@ -6,11 +8,18 @@ from datadog import initialize
 from datadog.api.events import Event
 from ddtrace import tracer
 from ddtrace.constants import ERROR_MSG, ERROR_TYPE
+from ddtrace.span import Span
 from discord.http import Route
 from wrapt import wrap_function_wrapper
 
 from . import __version__
 from .environment import running_in_pytest
+from .errors import (
+    AdminOnlyError,
+    UserBannedError,
+    UserUnverifiedError,
+    UserVerifiedError,
+)
 from .settings import Settings
 
 settings = Settings()
@@ -123,3 +132,11 @@ def add_span_error(ex: BaseException):  # pragma: no cover
             },
         )
         root.error = 1
+
+
+@skip_if_no_metrics
+def setup_ignored_errors(span: Span):  # pragma: no cover
+    span._ignore_exception(UserBannedError)  # type: ignore
+    span._ignore_exception(UserVerifiedError)  # type: ignore
+    span._ignore_exception(UserUnverifiedError)  # type: ignore
+    span._ignore_exception(AdminOnlyError)  # type: ignore


### PR DESCRIPTION
Some exceptions that cross datadog tracing context boundaries are not actually errors and are handled further up the stack. We need to ensure these are not treated as error traces for accurate error monitoring. Ignore these errors using the private interface that makes this possible. It's unfortunate that there isn't a public interface for this.
