### PR TITLE
Refactor how blocks work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Refactoring how user blocks work to ensure no one is placed in a game with someone they've blocked.
+
 ## [v7.12.3](https://github.com/lexicalunit/spellbot/releases/tag/v7.12.3) - 2022-02-22
 
 ### Changed

--- a/src/spellbot/interactions/block_interaction.py
+++ b/src/spellbot/interactions/block_interaction.py
@@ -31,6 +31,14 @@ class BlockInteraction(BaseInteraction):
 
         assert hasattr(target, "id")
         target_xid = target.id  # type: ignore
+
+        if self.ctx.author_id == target_xid:
+            return await safe_send_channel(
+                self.ctx,
+                "You can not block yourself.",
+                hidden=True,
+            )
+
         if action is ActionType.BLOCK:
             await self.services.users.block(self.ctx.author_id, target_xid)
         else:


### PR DESCRIPTION
The in-database SQL solution for filtering on user blocks does not seem to work all the time. This refactor now does this logic in-memory. This makes the logic significantly cleaner and less prone to bugs. It may be a little slower but I don't expect it to be significantly so.