### PR TITLE
Allow guild awards to be verified or unverifed only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Allow guild awards to be verified or unverifed only.
+
 ## [v8.1.0](https://github.com/lexicalunit/spellbot/releases/tag/v8.1.0) - 2022-10-15
 
 ### Added

--- a/src/spellbot/cogs/admin_cog.py
+++ b/src/spellbot/cogs/admin_cog.py
@@ -96,10 +96,20 @@ class AdminCog(commands.Cog):
         message: str,
         repeating: Optional[bool] = False,
         remove: Optional[bool] = False,
+        verified_only: Optional[bool] = False,
+        unverified_only: Optional[bool] = False,
     ) -> None:
         add_span_context(interaction)
         async with AdminAction.create(self.bot, interaction) as action:
-            await action.award_add(count, str(role), message, repeating=repeating, remove=remove)
+            await action.award_add(
+                count,
+                str(role),
+                message,
+                repeating=repeating,
+                remove=remove,
+                verified_only=verified_only,
+                unverified_only=unverified_only,
+            )
 
     @award_group.command(
         name="delete",

--- a/src/spellbot/migrations/versions/a1caf292fe93_adds_verified_only_and_unverified_only_.py
+++ b/src/spellbot/migrations/versions/a1caf292fe93_adds_verified_only_and_unverified_only_.py
@@ -1,0 +1,31 @@
+"""Adds verified_only and unverified_only to award table
+
+Revision ID: a1caf292fe93
+Revises: c0bc12b1b482
+Create Date: 2022-10-16 10:45:33.350102
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1caf292fe93"
+down_revision = "c0bc12b1b482"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "guild_awards",
+        sa.Column("verified_only", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+    op.add_column(
+        "guild_awards",
+        sa.Column("unverified_only", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("guild_awards", "unverified_only")
+    op.drop_column("guild_awards", "verified_only")

--- a/src/spellbot/models/award.py
+++ b/src/spellbot/models/award.py
@@ -52,6 +52,20 @@ class GuildAward(Base):
         server_default=false(),
         doc="If true, this award should be removed from instead of given to the player",
     )
+    verified_only = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=false(),
+        doc="If true, this award will only ever apply to verified users",
+    )
+    unverified_only = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=false(),
+        doc="If true, this award will only ever apply to unverified users",
+    )
     role = Column(
         String(100),
         nullable=False,
@@ -78,6 +92,8 @@ class GuildAward(Base):
             "remove": self.remove,
             "role": self.role,
             "message": self.message,
+            "verified_only": self.verified_only,
+            "unverified_only": self.unverified_only,
         }
 
 

--- a/src/spellbot/services/guilds.py
+++ b/src/spellbot/services/guilds.py
@@ -142,10 +142,12 @@ class GuildsService:
         role: str,
         message: str,
         **options: Optional[bool],
-    ) -> int:
+    ) -> dict[str, Any]:
         assert self.guild
         repeating = bool(options.get("repeating", False))
         remove = bool(options.get("remove", False))
+        verified_only = bool(options.get("verified_only", False))
+        unverified_only = bool(options.get("unverified_only", False))
         award = GuildAward(
             guild_xid=self.guild.xid,
             count=count,
@@ -153,10 +155,12 @@ class GuildsService:
             message=message,
             repeating=repeating,
             remove=remove,
+            verified_only=verified_only,
+            unverified_only=unverified_only,
         )  # type: ignore
         DatabaseSession.add(award)
         DatabaseSession.commit()
-        return award.id
+        return award.to_dict()
 
     @sync_to_async
     def award_delete(self, guild_award_id: int):

--- a/tests/cogs/test_admin_cog.py
+++ b/tests/cogs/test_admin_cog.py
@@ -450,18 +450,18 @@ class TestCogAdminAwards(InteractionMixin):
 
     async def test_award_add(self, cog: AdminCog):
         await self.run(cog.award_add, count=10, role="role", message="message", repeating=True)
+        award = DatabaseSession.query(GuildAward).one()
         assert self.last_send_message("embed") == {
             "author": {"name": "Award added!"},
             "color": self.settings.EMBED_COLOR,
             "description": (
-                "• _every 10 games_ — give `@role` — message\n\n"
+                f"• **ID {award.id}** — _every 10 games_ — give `@role` — message\n\n"
                 "You can view all awards with the `/set awards` command."
             ),
             "thumbnail": {"url": self.settings.ICO_URL},
             "type": "rich",
         }
         assert self.last_send_message("ephemeral")
-        award = DatabaseSession.query(GuildAward).one()
         assert award.count == 10
         assert award.role == "role"
         assert award.message == "message"

--- a/tests/models/test_award.py
+++ b/tests/models/test_award.py
@@ -16,4 +16,6 @@ class TestModelAward:
             "remove": guild_award.remove,
             "role": guild_award.role,
             "message": guild_award.message,
+            "unverified_only": guild_award.unverified_only,
+            "verified_only": guild_award.verified_only,
         }


### PR DESCRIPTION
Adds `unverified_only` and `verified_only` optional parameters to the `/award add` command. It will control if a user gets an award depending on if the user is verified or not.
