### PR TITLE
Allow multiple awards with same count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds the ability to have multiple guild awards with the same count number. Each award with the same count number that applies to a player will be granted when they reach that play count.
+
 ### Changed
 
 - Updated dependencies.

--- a/src/spellbot/actions/admin_action.py
+++ b/src/spellbot/actions/admin_action.py
@@ -242,14 +242,6 @@ class AdminAction(BaseAction):
             )
             return
 
-        if await self.services.guilds.has_award_with_count(count):
-            await safe_send_channel(
-                self.interaction,
-                "There's already an award for players who reach that many games.",
-                ephemeral=True,
-            )
-            return
-
         award = await self.services.guilds.award_add(
             count,
             role,

--- a/src/spellbot/actions/lfg_action.py
+++ b/src/spellbot/actions/lfg_action.py
@@ -405,24 +405,26 @@ class LookingForGameAction(BaseAction):
             player_xids,
         )
         assert self.interaction.guild
-        for player_xid, new_award in new_roles.items():
-            if player_xid not in fetched_players:
-                warning = (
-                    f"Unable to {'take' if new_award.remove else 'give'}"
-                    f" role {new_award.role}"
-                    f" {'from' if new_award.remove else 'to'}"
-                    f" user <@{player_xid}>"
+        for player_xid, new_awards in new_roles.items():
+            for new_award in new_awards:
+                if player_xid not in fetched_players:
+                    warning = (
+                        f"Unable to {'take' if new_award.remove else 'give'}"
+                        f" role {new_award.role}"
+                        f" {'from' if new_award.remove else 'to'}"
+                        f" user <@{player_xid}>"
+                    )
+                    await safe_followup_channel(self.interaction, warning)
+                    continue
+                player = fetched_players[player_xid]
+                print(f"adding role {new_award} to {player}")
+                await safe_add_role(
+                    player,
+                    self.interaction.guild,
+                    new_award.role,
+                    new_award.remove,
                 )
-                await safe_followup_channel(self.interaction, warning)
-                continue
-            player = fetched_players[player_xid]
-            await safe_add_role(
-                player,
-                self.interaction.guild,
-                new_award.role,
-                new_award.remove,
-            )
-            await safe_send_user(player, new_award.message)
+                await safe_send_user(player, new_award.message)
 
         # notifiy issues with player permissions
         if failed_xids:

--- a/src/spellbot/services/awards.py
+++ b/src/spellbot/services/awards.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 
 from asgiref.sync import sync_to_async
 from sqlalchemy.sql.expression import and_, or_
@@ -13,9 +13,9 @@ NewAward = namedtuple("NewAward", ["role", "message", "remove"])
 
 class AwardsService:
     @sync_to_async
-    def give_awards(self, guild_xid: int, player_xids: list[int]) -> dict[int, NewAward]:
+    def give_awards(self, guild_xid: int, player_xids: list[int]) -> dict[int, list[NewAward]]:
         """Returns dict of discord user ids -> role names to assign to that user."""
-        new_roles: dict[int, NewAward] = {}
+        new_roles: dict[int, list[NewAward]] = defaultdict(list)
 
         for player_xid in player_xids:
             plays = (
@@ -59,7 +59,7 @@ class AwardsService:
                 GuildAward.guild_xid == guild_xid,
             )
             if plays > 0:
-                next_award = award_q.filter(
+                next_awards = award_q.filter(
                     or_(
                         GuildAward.count == plays,
                         and_(
@@ -67,21 +67,24 @@ class AwardsService:
                             GuildAward.repeating.is_(True),
                         ),
                     ),
-                ).one_or_none()
-                if next_award and (
-                    (user_award.guild_award_id != next_award.id)
-                    or (user_award.guild_award_id == next_award.id and next_award.repeating)
-                ):
-                    if next_award.unverified_only and verified:
-                        continue
-                    if next_award.verified_only and not verified:
-                        continue
-                    new_roles[player_xid] = NewAward(
-                        next_award.role,
-                        next_award.message,
-                        next_award.remove,
-                    )
-                    user_award.guild_award_id = next_award.id  # type: ignore
+                ).all()
+                for next_award in next_awards:
+                    if next_award and (
+                        (user_award.guild_award_id != next_award.id)
+                        or (user_award.guild_award_id == next_award.id and next_award.repeating)
+                    ):
+                        if next_award.unverified_only and verified:
+                            continue
+                        if next_award.verified_only and not verified:
+                            continue
+                        new_roles[player_xid].append(
+                            NewAward(
+                                next_award.role,
+                                next_award.message,
+                                next_award.remove,
+                            )
+                        )
+                        user_award.guild_award_id = next_award.id  # type: ignore
         DatabaseSession.commit()
 
         return new_roles

--- a/tests/cogs/test_admin_cog.py
+++ b/tests/cogs/test_admin_cog.py
@@ -460,13 +460,3 @@ class TestCogAdminAwards(InteractionMixin):
             ephemeral=True,
         )
         assert DatabaseSession.query(GuildAward).count() == 0
-
-    async def test_award_add_dupe(self, cog: AdminCog):
-        await self.run(cog.award_add, count=10, role="role", message="message")
-        self.interaction.response.send_message.reset_mock()
-        await self.run(cog.award_add, count=10, role="role", message="message")
-        self.interaction.response.send_message.assert_called_once_with(
-            "There's already an award for players who reach that many games.",
-            ephemeral=True,
-        )
-        assert DatabaseSession.query(GuildAward).count() == 1

--- a/tests/services/test_awards.py
+++ b/tests/services/test_awards.py
@@ -26,7 +26,7 @@ class TestServiceAwards:
         )
         awards = AwardsService()
         give_outs = await awards.give_awards(guild_xid=guild.xid, player_xids=[user.xid])
-        assert give_outs == {user.xid: NewAward(role="one", message="msg", remove=False)}
+        assert give_outs == {user.xid: [NewAward(role="one", message="msg", remove=False)]}
 
     async def test_give_awards_when_plays_from_different_server(
         self,
@@ -111,8 +111,8 @@ class TestServiceAwards:
         )
         awards = AwardsService()
         give_outs = await awards.give_awards(guild_xid=guild.xid, player_xids=[user.xid])
-        assert give_outs == {user.xid: NewAward(role="one", message="msg", remove=False)}
+        assert give_outs == {user.xid: [NewAward(role="one", message="msg", remove=False)]}
         game2 = factories.game.create(guild=guild, channel=channel)
         factories.play.create(user_xid=user.xid, game_id=game2.id)
         give_outs = await awards.give_awards(guild_xid=guild.xid, player_xids=[user.xid])
-        assert give_outs == {user.xid: NewAward(role="one", message="msg", remove=False)}
+        assert give_outs == {user.xid: [NewAward(role="one", message="msg", remove=False)]}


### PR DESCRIPTION
Adds the ability to have multiple guild awards with the same count number. Each award with the same count number that applies to a player will be granted when they reach that play count.