### PR TITLE
Adds forget_channel command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds admin command `/forget_channel` to forget about deleted channels.
+
+### Changed
+
+- Changed `/channels` to list the Discord Channel IDs for channels listed.
+  These IDs can be used in the `/forget_channel` command to forget settings
+  for a channel. For example if the channel has been deleted.
+
 ## [v8.5.0](https://github.com/lexicalunit/spellbot/releases/tag/v8.5.0) - 2022-12-06
 
 ### Changed

--- a/src/spellbot/actions/admin_action.py
+++ b/src/spellbot/actions/admin_action.py
@@ -84,7 +84,7 @@ class AdminAction(BaseAction):
                     (f"`{k}`" if isinstance(v, bool) and v else f"`{k}={v}`")
                     for k, v in channel_settings.items()
                 )
-                next_line = f"• <#{channel['xid']}> — {deets}\n"
+                next_line = f"• <#{channel['xid']}> ({channel['xid']}) — {deets}\n"
                 if len(description) + len(next_line) >= EMBED_DESCRIPTION_SIZE_LIMIT:
                     embed.description = description
                     embeds.append(embed)
@@ -176,6 +176,16 @@ class AdminAction(BaseAction):
         )
         embed.color = discord.Color(self.settings.EMBED_COLOR)
         return embed
+
+    async def forget_channel(self, channel_str: str) -> None:
+        try:
+            channel_xid = int(channel_str)
+        except ValueError:
+            await safe_send_channel(self.interaction, "Invalid ID.", ephemeral=True)
+            return
+
+        await self.services.channels.forget(channel_xid)
+        await safe_send_channel(self.interaction, "Done.", ephemeral=True)
 
     async def info(self, game_id: str) -> None:
         numeric_filter = filter(str.isdigit, game_id)

--- a/src/spellbot/cogs/admin_cog.py
+++ b/src/spellbot/cogs/admin_cog.py
@@ -29,6 +29,14 @@ class AdminCog(commands.Cog):
         async with AdminAction.create(self.bot, interaction) as action:
             await action.setup()
 
+    @app_commands.command(name="forget_channel", description="Forget settings for a channel.")
+    @app_commands.describe(channel="What is the Discord ID of the channel?")
+    @tracer.wrap(name="interaction", resource="forget_channel")
+    async def forget_channel(self, interaction: discord.Interaction, channel: str) -> None:
+        add_span_context(interaction)
+        async with AdminAction.create(self.bot, interaction) as action:
+            await action.forget_channel(channel)
+
     set_group = app_commands.Group(name="set", description="...")
 
     @set_group.command(

--- a/src/spellbot/services/channels.py
+++ b/src/spellbot/services/channels.py
@@ -40,6 +40,10 @@ class ChannelsService:
         return channel.to_dict()
 
     @sync_to_async
+    def forget(self, xid: int) -> None:
+        DatabaseSession.query(Channel).filter(Channel.xid == xid).delete(synchronize_session=False)
+
+    @sync_to_async
     def select(self, xid: int) -> Optional[dict[str, Any]]:
         channel = DatabaseSession.query(Channel).filter(Channel.xid == xid).one_or_none()
         return channel.to_dict() if channel else None

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,7 +12,6 @@ import pytest_asyncio
 from aiohttp.test_utils import TestClient
 from click.testing import CliRunner
 from discord.ext import commands
-
 from spellbot import SpellBot
 from spellbot.client import build_bot
 from spellbot.database import (
@@ -24,6 +23,7 @@ from spellbot.database import (
 from spellbot.models import Channel, Game, Guild
 from spellbot.settings import Settings
 from spellbot.web import build_web_app
+
 from tests.factories import (
     BlockFactory,
     ChannelFactory,


### PR DESCRIPTION
### Added

- Adds admin command `/forget_channel` to forget about deleted channels.

### Changed

- Changed `/channels` to list the Discord Channel IDs for channels listed.
  These IDs can be used in the `/forget_channel` command to forget settings
  for a channel. For example if the channel has been deleted.