### PR TITLE
Check role hierarchy before attempting to manage roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Checks role hierarchy before attempting to manage roles.
+
 ## [v8.9.0](https://github.com/lexicalunit/spellbot/releases/tag/v8.9.0) - 2023-02-02
 
 ### Added

--- a/src/spellbot/models/guild.py
+++ b/src/spellbot/models/guild.py
@@ -85,6 +85,12 @@ class Guild(Base):
             "motd": self.motd,
             "show_links": self.show_links,
             "voice_create": self.voice_create,
-            "channels": [channel.to_dict() for channel in self.channels],
-            "awards": [award.to_dict() for award in self.awards],
+            "channels": sorted(
+                [channel.to_dict() for channel in self.channels],
+                key=lambda c: c["xid"],
+            ),
+            "awards": sorted(
+                [award.to_dict() for award in self.awards],
+                key=lambda c: c["id"],
+            ),
         }

--- a/src/spellbot/operations.py
+++ b/src/spellbot/operations.py
@@ -523,7 +523,8 @@ async def safe_add_role(
         )
         if not member or not hasattr(member, "roles"):
             logger.warning(
-                "warning: in guild %s, could not add role %s: could not find member: %s",
+                "warning: in guild %s (%s), could not manage role %s: could not find member: %s",
+                guild.name,
                 guild.id,
                 str(role),
                 str(user_or_member),
@@ -532,14 +533,19 @@ async def safe_add_role(
         discord_role = discord.utils.find(lambda m: m.name == role, guild.roles)
         if not discord_role:
             logger.warning(
-                "warning: in guild %s, could not add role: could not find role: %s",
+                "warning: in guild %s (%s), could not manage role: could not find role: %s",
+                guild.name,
                 guild.id,
                 str(role),
             )
             return
-        if not bot_can_role(guild):
+        if not bot_can_role(guild, discord_role):
             logger.warning(
-                "warning: in guild %s, could not add role: no permissions to add role: %s",
+                (
+                    "warning: in guild %s (%s), could not manage role:"
+                    " no permissions to manage role: %s"
+                ),
+                guild.name,
                 guild.id,
                 str(role),
             )
@@ -554,7 +560,8 @@ async def safe_add_role(
     ) as ex:
         add_span_error(ex)
         logger.exception(
-            "warning: in guild %s, could not add role to member %s: %s",
+            "warning: in guild %s (%s), could not add role to member %s: %s",
+            guild.name,
             guild.id,
             str(user_or_member),
             ex,

--- a/src/spellbot/utils.py
+++ b/src/spellbot/utils.py
@@ -65,12 +65,19 @@ def bot_can_reply_to(message: discord.Message) -> bool:
     return True
 
 
-def bot_can_role(guild: discord.Guild) -> bool:
+def bot_can_role(guild: discord.Guild, role: Optional[discord.Role] = None) -> bool:
     if not guild.me:
         return False
     perms = guild.me.guild_permissions
-    for req in ("manage_roles",):
-        if not hasattr(perms, req) or not getattr(perms, req):
+    req = "manage_roles"
+    if not hasattr(perms, req) or not getattr(perms, req):
+        return False
+    if role is not None:
+        try:
+            role_hierarchy = list(guild.roles)
+            if role_hierarchy.index(role) > role_hierarchy.index(guild.me.top_role):
+                return False
+        except ValueError:
             return False
     return True
 

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -127,6 +127,7 @@ def build_client_user() -> discord.User:
     client_user.id = CLIENT_USER_ID
     client_user.display_name = "SpellBot"
     client_user.mention = f"<@{client_user.id}>"
+    client_user.top_role = None
     return client_user
 
 
@@ -137,6 +138,7 @@ def build_author(offset: int = 1) -> discord.User:
     author.mention = f"<@{author.id}>"
     author.send = AsyncMock()
     author.roles = []
+    author.top_role = None
     return author
 
 

--- a/tests/models/test_guild.py
+++ b/tests/models/test_guild.py
@@ -19,6 +19,12 @@ class TestModelGuild:
             "motd": guild.motd,
             "show_links": guild.show_links,
             "voice_create": guild.voice_create,
-            "channels": [channel1.to_dict(), channel2.to_dict()],
-            "awards": [award1.to_dict(), award2.to_dict()],
+            "channels": sorted(
+                [channel1.to_dict(), channel2.to_dict()],
+                key=lambda c: c["xid"],
+            ),
+            "awards": sorted(
+                [award1.to_dict(), award2.to_dict()],
+                key=lambda c: c["id"],
+            ),
         }


### PR DESCRIPTION
**Description**

Checks the role hierarchy before attempting to manage roles. A bot can not add/remove roles to/from a user if that role is higher in the hierarchy than the bot's top role.

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
