### PR TITLE
Automatically clean deleted channels on /channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Applied more linting and formatting rules from ruff.
+
+### Added
+
+- Automatically clean deleted channels when running the /channels command.
+
 ## [v8.10.1](https://github.com/lexicalunit/spellbot/releases/tag/v8.10.1) - 2023-04-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,6 @@
 include = '\.pyi?$'
 line-length = 100
 
-[tool.isort]
-ensure_newline_before_comments = true
-include_trailing_comma = true
-line_length = 100
-multi_line_output = 3
-use_parentheses = true
-
 [tool.pylint]
 max-line-length = 100
 
@@ -19,10 +12,47 @@ reportMissingTypeArgument = true
 typeCheckingMode = "basic"
 
 [tool.ruff]
-exclude = [".git", "env"]
-ignore = ["E", "W"]
+exclude = [
+  "__pypackages__",
+  "_build",
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".env",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "buck-out",
+  "build",
+  "dist",
+  "env",
+  "node_modules",
+  "venv",
+  "src/spellbot/migrations/versions",
+]
+extend-select = [
+  "ANN",
+  "C4",
+  "COM812",
+  "DTZ",
+  "I",
+  "ISC",
+  "PT",
+  "PTH",
+  "Q",
+  "RUF",
+  "T20",
+  "W",
+]
+ignore = ["ANN101", "ANN102", "ANN401"]
 line-length = 100
-select = ["F", "E501", "T201", "T203", "I001"]
 target-version = "py310"
 
 [tool.pylic]

--- a/scripts/create_db_revision.py
+++ b/scripts/create_db_revision.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 import sys
-from os.path import dirname, realpath
+from os.path import realpath
 from pathlib import Path
 
 import alembic
 import alembic.command
 import alembic.config
 
-SRC_ROOT = Path(dirname(realpath(__file__))).parent
+SRC_ROOT = Path(realpath(__file__)).parent.parent
 SPELLBOT_DIR = SRC_ROOT / "src" / "spellbot"
 MIGRATIONS_DIR = SPELLBOT_DIR / "migrations"
 ALEMBIC_INI = MIGRATIONS_DIR / "alembic.ini"

--- a/src/spellbot/_version.py
+++ b/src/spellbot/_version.py
@@ -24,13 +24,13 @@ def version_from_package() -> Optional[str]:
 
 
 def version_from_toml() -> Optional[str]:
-    from os.path import dirname, realpath
+    from os.path import realpath
     from pathlib import Path
 
     import toml
 
     try:
-        pkg_root = dirname(realpath(__file__))
+        pkg_root = Path(realpath(__file__)).parent
         src_root = Path(pkg_root).parent
         repo_root = src_root.parent
         pyproject = toml.load(repo_root / "pyproject.toml")

--- a/src/spellbot/actions/base_action.py
+++ b/src/spellbot/actions/base_action.py
@@ -44,7 +44,7 @@ class BaseAction:
     channel: Optional[discord.TextChannel]
     channel_data: dict[str, Any]
 
-    def __init__(self, bot: SpellBot, interaction: discord.Interaction):
+    def __init__(self, bot: SpellBot, interaction: discord.Interaction) -> None:
         self.bot = bot
         self.services = ServicesRegistry()
         self.interaction = interaction

--- a/src/spellbot/actions/score_action.py
+++ b/src/spellbot/actions/score_action.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class ScoreAction(BaseAction):
-    async def execute(self, target: Union[discord.Member, discord.User]):
+    async def execute(self, target: Union[discord.Member, discord.User]) -> None:
         assert self.interaction.guild
         guild_name = self.interaction.guild.name
         assert hasattr(target, "id")
@@ -33,7 +33,7 @@ class ScoreAction(BaseAction):
         embed.color = settings.EMBED_COLOR
         await safe_send_channel(self.interaction, embed=embed, ephemeral=True)
 
-    async def history(self):
+    async def history(self) -> None:
         assert self.interaction.channel
         assert hasattr(self.interaction.channel, "name")
         channel_name = self.interaction.channel.name  # type: ignore
@@ -48,7 +48,7 @@ class ScoreAction(BaseAction):
         embed.color = settings.EMBED_COLOR
         await safe_send_channel(self.interaction, embed=embed, ephemeral=True)
 
-    async def top(self, monthly: bool, ago: int):
+    async def top(self, monthly: bool, ago: int) -> None:
         if not monthly:
             ago = 0  # "months ago" doesn't make sense for "all time" range
 

--- a/src/spellbot/actions/watch_action.py
+++ b/src/spellbot/actions/watch_action.py
@@ -28,7 +28,7 @@ class WatchAction(BaseAction):
         target: Optional[Union[discord.User, discord.Member]] = None,
         id: Optional[int] = None,
         note: Optional[str] = None,
-    ):
+    ) -> None:
         if target:
             await self.services.users.upsert(target)
 
@@ -50,14 +50,18 @@ class WatchAction(BaseAction):
             await self.services.users.watch(self.interaction.guild_id, target_xid, note=note)
             await safe_send_channel(self.interaction, f"Watching <@{target_xid}>.", ephemeral=True)
 
-    async def watch(self, target: Union[discord.User, discord.Member], note: Optional[str] = None):
+    async def watch(
+        self,
+        target: Union[discord.User, discord.Member],
+        note: Optional[str] = None,
+    ) -> None:
         await self.execute(ActionType.WATCH, target=target, note=note)
 
     async def unwatch(
         self,
         target: Optional[Union[discord.User, discord.Member]] = None,
         id: Optional[str] = None,
-    ):
+    ) -> None:
         if not target and not id:
             await safe_send_channel(
                 self.interaction,
@@ -114,6 +118,6 @@ class WatchAction(BaseAction):
 
         return embeds
 
-    async def watched(self, page: int):
+    async def watched(self, page: int) -> None:
         embeds: list[Embed] = await self.get_watched_embeds()
         await safe_send_channel(self.interaction, embed=embeds[page - 1])

--- a/src/spellbot/cli.py
+++ b/src/spellbot/cli.py
@@ -136,7 +136,7 @@ def main(
             # since those only start after the ready signal has been processed.
             # As such, let's check every 30 minutes if the bot is ready, because if
             # it isn't we can just kill it and have supervisord restart it for us.
-            def killer(bot: SpellBot):
+            def killer(bot: SpellBot) -> None:
                 while True:
                     time.sleep(30 * 60)  # 30 minute wait
                     if not bot.is_ready():

--- a/src/spellbot/cogs/about_cog.py
+++ b/src/spellbot/cogs/about_cog.py
@@ -19,7 +19,7 @@ PATREON = "https://www.patreon.com/lexicalunit"
 
 @for_all_callbacks(app_commands.check(is_guild))
 class AboutCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(name="about", description="Get information about SpellBot.")
@@ -47,5 +47,5 @@ class AboutCog(commands.Cog):
         await safe_send_channel(interaction, embed=embed)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(AboutCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/admin_cog.py
+++ b/src/spellbot/cogs/admin_cog.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @for_all_callbacks(app_commands.check(is_admin))
 @for_all_callbacks(app_commands.check(is_guild))
 class AdminCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(name="setup", description="Setup SpellBot on your server.")
@@ -223,5 +223,5 @@ class AdminCog(commands.Cog):
             await action.set_show_points(setting)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(AdminCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/block_cog.py
+++ b/src/spellbot/cogs/block_cog.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 @for_all_callbacks(app_commands.check(is_guild))
 class BlockCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(
@@ -24,7 +24,7 @@ class BlockCog(commands.Cog):
     )
     @app_commands.describe(target="The user to block")
     @tracer.wrap(name="interaction", resource="block")
-    async def block(self, interaction: discord.Interaction, target: discord.Member):
+    async def block(self, interaction: discord.Interaction, target: discord.Member) -> None:
         add_span_context(interaction)
         async with BlockAction.create(self.bot, interaction) as action:
             await action.block(target=target)
@@ -35,11 +35,11 @@ class BlockCog(commands.Cog):
     )
     @app_commands.describe(target="The user to unblock")
     @tracer.wrap(name="interaction", resource="unblock")
-    async def unblock(self, interaction: discord.Interaction, target: discord.Member):
+    async def unblock(self, interaction: discord.Interaction, target: discord.Member) -> None:
         add_span_context(interaction)
         async with BlockAction.create(self.bot, interaction) as action:
             await action.unblock(target=target)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(BlockCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/config_cog.py
+++ b/src/spellbot/cogs/config_cog.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 @for_all_callbacks(app_commands.check(is_guild))
 class ConfigCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(
@@ -48,5 +48,5 @@ class ConfigCog(commands.Cog):
                 await action.power(level=level)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(ConfigCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/events_cog.py
+++ b/src/spellbot/cogs/events_cog.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @for_all_callbacks(app_commands.check(is_admin))
 @for_all_callbacks(app_commands.check(is_guild))
 class EventsCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(name="game", description="Immediately create and start an ad-hoc game.")
@@ -42,5 +42,5 @@ class EventsCog(commands.Cog):
             await action.create_game(players, format)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(EventsCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/leave_cog.py
+++ b/src/spellbot/cogs/leave_cog.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 @for_all_callbacks(app_commands.check(is_guild))
 class LeaveGameCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     # Normally this function would be named "leave" to match the command name like
@@ -29,5 +29,5 @@ class LeaveGameCog(commands.Cog):
             await action.execute()
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(LeaveGameCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/lfg_cog.py
+++ b/src/spellbot/cogs/lfg_cog.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @for_all_callbacks(app_commands.check(is_guild))
 class LookingForGameCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(name="lfg", description="Looking for game.")
@@ -42,7 +42,7 @@ class LookingForGameCog(commands.Cog):
         friends: Optional[str] = None,
         seats: Optional[int] = None,
         format: Optional[int] = None,
-    ):
+    ) -> None:
         assert interaction.channel_id is not None
         add_span_context(interaction)
         await interaction.response.defer()
@@ -51,5 +51,5 @@ class LookingForGameCog(commands.Cog):
                 await action.execute(friends=friends, seats=seats, format=format)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(LookingForGameCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/owner_cog.py
+++ b/src/spellbot/cogs/owner_cog.py
@@ -16,7 +16,7 @@ from ..utils import for_all_callbacks
 logger = logging.getLogger(__name__)
 
 
-async def set_banned(banned: bool, ctx: commands.Context[SpellBot], arg: Optional[str]):
+async def set_banned(banned: bool, ctx: commands.Context[SpellBot], arg: Optional[str]) -> None:
     assert ctx.message
     if arg is None:
         return await safe_send_user(ctx.message.author, "No target user.")
@@ -34,12 +34,12 @@ async def set_banned(banned: bool, ctx: commands.Context[SpellBot], arg: Optiona
 
 @for_all_callbacks(commands.is_owner())
 class OwnerCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @commands.command(name="ban")
     @tracer.wrap(name="interaction", resource="ban")
-    async def ban(self, ctx: commands.Context[SpellBot], arg: Optional[str] = None):
+    async def ban(self, ctx: commands.Context[SpellBot], arg: Optional[str] = None) -> None:
         add_span_context(ctx)
         async with db_session_manager():
             try:
@@ -49,7 +49,7 @@ class OwnerCog(commands.Cog):
 
     @commands.command(name="unban")
     @tracer.wrap(name="interaction", resource="unban")
-    async def unban(self, ctx: commands.Context[SpellBot], arg: Optional[str] = None):
+    async def unban(self, ctx: commands.Context[SpellBot], arg: Optional[str] = None) -> None:
         add_span_context(ctx)
         async with db_session_manager():
             try:
@@ -59,7 +59,7 @@ class OwnerCog(commands.Cog):
 
     @commands.command(name="stats")
     @tracer.wrap(name="interaction", resource="stats")
-    async def stats(self, ctx: commands.Context[SpellBot]):
+    async def stats(self, ctx: commands.Context[SpellBot]) -> None:
         add_span_context(ctx)
         await safe_send_user(
             ctx.message.author,
@@ -73,17 +73,17 @@ class OwnerCog(commands.Cog):
                     guilds:   {len(self.bot.guilds)}
                     users:    {len(self.bot.users)}
                     ```
-                """
+                """,
             ),
         )
 
     @commands.command(name="naughty")
     @tracer.wrap(name="interaction", resource="naughty")
-    async def naughty(self, ctx: commands.Context[SpellBot]):
+    async def naughty(self, ctx: commands.Context[SpellBot]) -> None:
         add_span_context(ctx)
         resp = "\n".join([f"<@{xid}> ({xid})" for xid in bad_users])
         await safe_send_user(ctx.message.author, f"Naughty users: {resp}")
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(OwnerCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/score_cog.py
+++ b/src/spellbot/cogs/score_cog.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @for_all_callbacks(app_commands.check(is_guild))
 class ScoreCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(
@@ -59,5 +59,5 @@ class ScoreCog(commands.Cog):
             await action.top(monthly, ago)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(ScoreCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/sync_cog.py
+++ b/src/spellbot/cogs/sync_cog.py
@@ -13,13 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class SyncCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @commands.command(name="sync")
     @commands.is_owner()
     @tracer.wrap(name="interaction", resource="sync")
-    async def sync(self, ctx: commands.Context[SpellBot]):
+    async def sync(self, ctx: commands.Context[SpellBot]) -> None:
         add_span_context(self.bot)
         try:
             await load_extensions(self.bot, do_sync=True)
@@ -32,5 +32,5 @@ class SyncCog(commands.Cog):
             await handle_exception(ex)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(SyncCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/tasks_cog.py
+++ b/src/spellbot/cogs/tasks_cog.py
@@ -22,14 +22,14 @@ async def wait_until_ready(bot: SpellBot) -> None:
 
 
 class TasksCog(commands.Cog):  # pragma: no cover
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
         if not running_in_pytest():
             self.cleanup_old_voice_channels.start()  # pylint: disable=no-member
             self.expire_inactive_games.start()  # pylint: disable=no-member
 
     @tasks.loop(minutes=settings.VOICE_CLEANUP_LOOP_M)
-    async def cleanup_old_voice_channels(self):
+    async def cleanup_old_voice_channels(self) -> None:
         try:
             with tracer.trace(name="command", resource="cleanup_old_voice_channels"):
                 async with TasksAction.create(self.bot) as interaction:
@@ -38,11 +38,11 @@ class TasksCog(commands.Cog):  # pragma: no cover
             logger.exception("error: exception in task cog: %s", e)
 
     @cleanup_old_voice_channels.before_loop
-    async def before_cleanup_old_voice_channels(self):
+    async def before_cleanup_old_voice_channels(self) -> None:
         await wait_until_ready(self.bot)
 
     @tasks.loop(minutes=settings.EXPIRE_GAMES_LOOP_M)
-    async def expire_inactive_games(self):
+    async def expire_inactive_games(self) -> None:
         try:
             with tracer.trace(name="command", resource="expire_inactive_games"):
                 async with TasksAction.create(self.bot) as interaction:
@@ -51,9 +51,9 @@ class TasksCog(commands.Cog):  # pragma: no cover
             logger.exception("error: exception in task cog: %s", e)
 
     @expire_inactive_games.before_loop
-    async def before_expire_inactive_games(self):
+    async def before_expire_inactive_games(self) -> None:
         await wait_until_ready(self.bot)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(TasksCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/verify_cog.py
+++ b/src/spellbot/cogs/verify_cog.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 @for_all_callbacks(app_commands.check(is_admin))
 @for_all_callbacks(app_commands.check(is_guild))
 class VerifyCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(name="verify", description="Verify a user.")
@@ -45,5 +45,5 @@ class VerifyCog(commands.Cog):
             await action.unverify(target=target)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(VerifyCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/cogs/watch_cog.py
+++ b/src/spellbot/cogs/watch_cog.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 @for_all_callbacks(app_commands.check(is_admin))
 @for_all_callbacks(app_commands.check(is_guild))
 class WatchCog(commands.Cog):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
 
     @app_commands.command(
@@ -26,10 +26,11 @@ class WatchCog(commands.Cog):
     )
     @app_commands.describe(page="If there are multiple pages of output, which one?")
     @tracer.wrap(name="interaction", resource="watched")
-    async def watched(self, interaction: discord.Interaction, page: Optional[int] = 1):
+    async def watched(self, interaction: discord.Interaction, page: Optional[int] = 1) -> None:
         add_span_context(interaction)
         async with WatchAction.create(self.bot, interaction) as action:
-            assert page and page >= 1
+            assert page
+            assert page >= 1
             await action.watched(page=page)
 
     @app_commands.command(
@@ -44,7 +45,7 @@ class WatchCog(commands.Cog):
         interaction: discord.Interaction,
         target: Union[discord.User, discord.Member],
         note: Optional[str] = None,
-    ):
+    ) -> None:
         add_span_context(interaction)
         async with WatchAction.create(self.bot, interaction) as action:
             await action.watch(target=target, note=note)
@@ -61,11 +62,11 @@ class WatchCog(commands.Cog):
         interaction: discord.Interaction,
         target: Optional[Union[discord.User, discord.Member]] = None,
         id: Optional[str] = None,
-    ):
+    ) -> None:
         add_span_context(interaction)
         async with WatchAction.create(self.bot, interaction) as action:
             await action.unwatch(target=target, id=id)
 
 
-async def setup(bot: SpellBot):  # pragma: no cover
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
     await bot.add_cog(WatchCog(bot), guild=bot.settings.GUILD_OBJECT)

--- a/src/spellbot/errors.py
+++ b/src/spellbot/errors.py
@@ -10,25 +10,25 @@ class SpellBotError(AppCommandError):
 
 
 class AdminOnlyError(SpellBotError):
-    def __init__(self, message: Optional[str] = None):
+    def __init__(self, message: Optional[str] = None) -> None:
         super().__init__(message or "This command is only available to SpellBot admins.")
 
 
 class GuildOnlyError(SpellBotError):
-    def __init__(self, message: Optional[str] = None):
+    def __init__(self, message: Optional[str] = None) -> None:
         super().__init__(message or "This command is only available within a guild.")
 
 
 class UserBannedError(SpellBotError):
-    def __init__(self, message: Optional[str] = None):
+    def __init__(self, message: Optional[str] = None) -> None:
         super().__init__(message or "This user has been banned from using SpellBot.")
 
 
 class UserVerifiedError(SpellBotError):
-    def __init__(self, message: Optional[str] = None):
+    def __init__(self, message: Optional[str] = None) -> None:
         super().__init__(message or "Verified user message in a unverified only channel.")
 
 
 class UserUnverifiedError(SpellBotError):
-    def __init__(self, message: Optional[str] = None):
+    def __init__(self, message: Optional[str] = None) -> None:
         super().__init__(message or "Unverified user message in a verified only channel.")

--- a/src/spellbot/logs.py
+++ b/src/spellbot/logs.py
@@ -6,7 +6,7 @@ import coloredlogs
 
 
 # Note: be sure to call this before importing any application modules!
-def configure_logging(level: Union[int, str]):  # pragma: no cover
+def configure_logging(level: Union[int, str]) -> None:  # pragma: no cover
     coloredlogs.install(
         level=level,
         fmt="[%(asctime)s][%(name)s][%(levelname)s] - %(message)s",

--- a/src/spellbot/metrics.py
+++ b/src/spellbot/metrics.py
@@ -50,7 +50,12 @@ def patch_discord() -> None:  # pragma: no cover
     interaction_callback = re.compile(r"/interactions/([0-9]+)/([^/]+)/callback")
     webhook_message = re.compile(r"/webhooks/([0-9]+)/([^/]+)/messages/@original")
 
-    def request(wrapped: Callable, instance, args, kwargs):  # type: ignore # pragma: no cover
+    def request(
+        wrapped: Callable,  # type: ignore # pragma: no cover
+        instance,  # noqa # type: ignore # pragma: no cover
+        args,  # noqa # type: ignore # pragma: no cover
+        kwargs,  # noqa # type: ignore # pragma: no cover
+    ) -> Any:
         route: Route = args[0]
         path: str = route.path
         additional_tags = {}
@@ -68,9 +73,9 @@ def patch_discord() -> None:  # pragma: no cover
             span.set_tags(
                 {
                     "base": route.BASE,
-                    "channel_id": str(route.channel_id),
+                    "channel_xid": str(route.channel_id),
                     "data": kwargs,
-                    "guild_id": str(route.guild_id),
+                    "guild_xid": str(route.guild_id),
                     "instance": instance,
                     "method": route.method,
                     **additional_tags,
@@ -99,7 +104,7 @@ def alert_error(
 
 
 @skip_if_no_metrics
-def add_span_context(interaction: Any):  # pragma: no cover
+def add_span_context(interaction: Any) -> None:  # pragma: no cover
     if span := tracer.current_span():
         if interaction_id := getattr(interaction, "id", None):
             span.set_tag("interaction_id", interaction_id)
@@ -118,7 +123,7 @@ def add_span_context(interaction: Any):  # pragma: no cover
 
 
 @skip_if_no_metrics
-def add_span_error(ex: BaseException):  # pragma: no cover
+def add_span_error(ex: BaseException) -> None:  # pragma: no cover
     if span := tracer.current_span():
         span.set_exc_info(ex.__class__, ex, getattr(ex, "__traceback__", None))
 
@@ -133,7 +138,7 @@ def add_span_error(ex: BaseException):  # pragma: no cover
 
 
 @skip_if_no_metrics
-def setup_ignored_errors(span: Span):  # pragma: no cover
+def setup_ignored_errors(span: Span) -> None:  # pragma: no cover
     span._ignore_exception(AdminOnlyError)  # type: ignore
     span._ignore_exception(GuildOnlyError)  # type: ignore
     span._ignore_exception(UserBannedError)  # type: ignore

--- a/src/spellbot/migrations/env.py
+++ b/src/spellbot/migrations/env.py
@@ -10,7 +10,7 @@ config = context.config
 target_metadata = Base.metadata
 
 
-def run_migrations_offline():
+def run_migrations_offline() -> None:
     """
     Run migrations in 'offline' mode.
 
@@ -33,7 +33,7 @@ def run_migrations_offline():
         context.run_migrations()
 
 
-def run_migrations_online():
+def run_migrations_online() -> None:
     """
     Run migrations in 'online' mode.
 

--- a/src/spellbot/models/__init__.py
+++ b/src/spellbot/models/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from pkgutil import iter_modules
 
 
-def import_models():  # pragma: no cover
+def import_models() -> None:  # pragma: no cover
     package_dir = Path(__file__).resolve().parent
     for info in iter_modules([str(package_dir)]):
         module = import_module(f"{__name__}.{info.name}")
@@ -16,18 +16,18 @@ def import_models():  # pragma: no cover
                     globals()[name] = _object
 
 
-from .base import Base, create_all, literalquery, now, reverse_all  # noqa: I001
+from .base import Base, create_all, literalquery, now, reverse_all  # noqa: I001,E402
 
-from .award import GuildAward, UserAward
-from .block import Block
-from .channel import Channel
-from .config import Config
-from .game import Game, GameFormat, GameStatus
-from .guild import Guild
-from .play import Play
-from .user import User
-from .verify import Verify
-from .watch import Watch
+from .award import GuildAward, UserAward  # noqa: E402
+from .block import Block  # noqa: E402
+from .channel import Channel  # noqa: E402
+from .config import Config  # noqa: E402
+from .game import Game, GameFormat, GameStatus  # noqa: E402
+from .guild import Guild  # noqa: E402
+from .play import Play  # noqa: E402
+from .user import User  # noqa: E402
+from .verify import Verify  # noqa: E402
+from .watch import Watch  # noqa: E402
 
 __all__ = [
     "Base",

--- a/src/spellbot/models/base.py
+++ b/src/spellbot/models/base.py
@@ -51,10 +51,10 @@ def reverse_all(DATABASE_URL: str) -> None:
 
 
 class StringLiteral(String):  # pragma: no cover
-    def literal_processor(self, dialect: Any):
+    def literal_processor(self, dialect: Any) -> Any:
         super_processor = super().literal_processor(dialect)
 
-        def process(value: Any):
+        def process(value: Any) -> Any:
             if isinstance(value, int):
                 return text(value)  # type: ignore
             if not isinstance(value, str):
@@ -67,7 +67,7 @@ class StringLiteral(String):  # pragma: no cover
         return process
 
 
-def literalquery(statement: Any):  # pragma: no cover
+def literalquery(statement: Any) -> str:  # pragma: no cover
     """WARNING: This is **insecure**. DO NOT execute returned strings."""
     import sqlalchemy.orm
 

--- a/src/spellbot/models/game.py
+++ b/src/spellbot/models/game.py
@@ -30,14 +30,14 @@ FormatDetails = namedtuple("FormatDetails", ["players"])
 class GameFormat(Enum):
     """A Magic: The Gathering game format."""
 
-    def __new__(cls, *args: Any, **kwargs: Any):  # pylint: disable=W0613
+    def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # pylint: disable=W0613
         """Give each enum value an increasing numerical value starting at 1."""
         value = len(cls.__members__) + 1
         obj = object.__new__(cls)
         obj._value_ = value
         return obj
 
-    def __init__(self, players: int):
+    def __init__(self, players: int) -> None:
         """Each enum has certain additional properties taken from FormatDetails."""
         self.players = players
 

--- a/src/spellbot/services/__init__.py
+++ b/src/spellbot/services/__init__.py
@@ -13,7 +13,7 @@ from .watches import WatchesService
 
 
 class ServicesRegistry:
-    def __init__(self):
+    def __init__(self) -> None:
         self.awards = AwardsService()
         self.channels = ChannelsService()
         self.configs = ConfigsService()

--- a/src/spellbot/services/awards.py
+++ b/src/spellbot/services/awards.py
@@ -82,7 +82,7 @@ class AwardsService:
                                 next_award.role,
                                 next_award.message,
                                 next_award.remove,
-                            )
+                            ),
                         )
                         user_award.guild_award_id = next_award.id  # type: ignore
         DatabaseSession.commit()

--- a/src/spellbot/services/channels.py
+++ b/src/spellbot/services/channels.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 import discord
+import pytz
 from asgiref.sync import sync_to_async
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql.expression import update
@@ -22,7 +23,7 @@ class ChannelsService:
             "xid": channel.id,
             "guild_xid": channel.guild.id,
             "name": name,
-            "updated_at": datetime.utcnow(),
+            "updated_at": datetime.now(tz=pytz.utc),
         }
         upsert = insert(Channel).values(**values)
         upsert = upsert.on_conflict_do_update(

--- a/src/spellbot/services/guilds.py
+++ b/src/spellbot/services/guilds.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 import discord
+import pytz
 from asgiref.sync import sync_to_async
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql.expression import and_
@@ -13,7 +14,7 @@ from ..models import Channel, Guild, GuildAward
 
 
 class GuildsService:
-    def __init__(self):
+    def __init__(self) -> None:
         self.guild: Optional[Guild] = None
 
     @sync_to_async()
@@ -24,7 +25,7 @@ class GuildsService:
         values = {
             "xid": guild.id,
             "name": name,
-            "updated_at": datetime.utcnow(),
+            "updated_at": datetime.now(tz=pytz.utc),
         }
         upsert = insert(Guild).values(**values)
         upsert = upsert.on_conflict_do_update(
@@ -152,7 +153,7 @@ class GuildsService:
         return award.to_dict()
 
     @sync_to_async
-    def award_delete(self, guild_award_id: int):
+    def award_delete(self, guild_award_id: int) -> None:
         assert self.guild
         award = DatabaseSession.query(GuildAward).get(guild_award_id)
         if award:

--- a/src/spellbot/services/plays.py
+++ b/src/spellbot/services/plays.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 from typing import Any, Optional
 
+import pytz
 from asgiref.sync import sync_to_async
 from dateutil import tz
 from dateutil.relativedelta import relativedelta
@@ -241,7 +242,7 @@ class PlaysService:
             Game.channel_xid == channel_xid,
         ]
         if monthly:
-            target = datetime.date.today() + relativedelta(months=-ago)
+            target = datetime.datetime.now(tz=pytz.utc).date() + relativedelta(months=-ago)
             filters.append(extract("year", Game.started_at) == target.year)
             filters.append(extract("month", Game.started_at) == target.month)
         result = (

--- a/src/spellbot/services/users.py
+++ b/src/spellbot/services/users.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Optional, Union
 
 import discord
+import pytz
 from asgiref.sync import sync_to_async
 from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert
@@ -14,7 +15,7 @@ from ..models import Block, Game, User, Watch
 
 
 class UsersService:
-    def __init__(self):
+    def __init__(self) -> None:
         self.user: Optional[User] = None
 
     @sync_to_async
@@ -24,7 +25,7 @@ class UsersService:
         max_name_len = User.name.property.columns[0].type.length  # type: ignore
         raw_name = getattr(target, "display_name", "")
         name = raw_name[:max_name_len]
-        values = {"xid": xid, "name": name, "updated_at": datetime.utcnow()}
+        values = {"xid": xid, "name": name, "updated_at": datetime.now(tz=pytz.utc)}
         upsert = insert(User).values(**values)
         upsert = upsert.on_conflict_do_update(
             index_elements=[User.xid],
@@ -50,7 +51,7 @@ class UsersService:
         values = {
             "xid": xid,
             "name": "Unknown User",
-            "updated_at": datetime.utcnow(),
+            "updated_at": datetime.now(tz=pytz.utc),
             "banned": banned,
         }
         upsert = insert(User).values(**values)
@@ -84,7 +85,7 @@ class UsersService:
         query = (
             update(Game)
             .where(Game.id == left_game_id)
-            .values(updated_at=datetime.utcnow())
+            .values(updated_at=datetime.now(tz=pytz.utc))
             .execution_options(synchronize_session=False)
         )
         DatabaseSession.execute(query)

--- a/src/spellbot/services/verifies.py
+++ b/src/spellbot/services/verifies.py
@@ -11,7 +11,7 @@ from ..models import Verify
 
 
 class VerifiesService:
-    def __init__(self):
+    def __init__(self) -> None:
         self.current: Optional[Verify] = None
 
     @sync_to_async

--- a/src/spellbot/settings.py
+++ b/src/spellbot/settings.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from os import getenv
 from typing import Optional
 
+import pytz
 from discord import Object
 from discord.abc import Snowflake
 
@@ -12,7 +13,7 @@ from .environment import running_in_pytest
 
 
 class Settings:
-    def __init__(self, guild_xid: Optional[int] = None):
+    def __init__(self, guild_xid: Optional[int] = None) -> None:
         self.guild_xid = guild_xid
 
         # content
@@ -68,7 +69,7 @@ class Settings:
         self.EXPIRE_TIME_M = 45  # 45 minutes
 
     def workaround_over_eager_caching(self, url: str) -> str:
-        return f"{url}?{datetime.today().strftime('%Y-%m-%d')}"
+        return f"{url}?{datetime.now(tz=pytz.utc).date().strftime('%Y-%m-%d')}"
 
     @property
     def THUMB_URL(self) -> str:

--- a/src/spellbot/utils.py
+++ b/src/spellbot/utils.py
@@ -185,15 +185,15 @@ class suppress(AbstractContextManager[None]):
     be able to understand that code following the context is reachable.
     """
 
-    def __init__(self, *exceptions: Type[Exception], log: str, **kwargs: Any):
+    def __init__(self, *exceptions: Type[Exception], log: str, **kwargs: Any) -> None:
         self._exceptions = exceptions
         self._log = log
         self._kwargs = kwargs
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exctype: Type[Exception], excinst: Exception, exctb: Traceback):
+    def __exit__(self, exctype: Type[Exception], excinst: Exception, exctb: Traceback) -> bool:
         if captured := exctype is not None and issubclass(exctype, self._exceptions):
             log_warning(self._log, exec_info=True, **self._kwargs)
             if span := tracer.current_span():  # pragma: no cover
@@ -211,7 +211,7 @@ class suppress(AbstractContextManager[None]):
 
 # I have no idea how to properly type hint this.
 def for_all_callbacks(decorator: Any) -> Any:
-    def decorate(cls: Any):
+    def decorate(cls: Any) -> Any:
         for attr in cls.__dict__:
             method = getattr(cls, attr)
             if isinstance(method, (AppCommand, ExtCommand)):

--- a/src/spellbot/views/base_view.py
+++ b/src/spellbot/views/base_view.py
@@ -7,7 +7,7 @@ from ..utils import handle_view_errors
 
 
 class BaseView(discord.ui.View):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         super().__init__(timeout=None)
         self.bot = bot
         self.on_error = handle_view_errors

--- a/src/spellbot/views/lfg_view.py
+++ b/src/spellbot/views/lfg_view.py
@@ -56,13 +56,13 @@ class PendingGameView(BaseView):
 
 
 class StartedGameView(BaseView):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         super().__init__(bot)
         self.add_item(StartedGameSelect(self.bot))
 
 
 class StartedGameSelect(ui.Select[StartedGameView]):
-    def __init__(self, bot: SpellBot):
+    def __init__(self, bot: SpellBot) -> None:
         self.bot = bot
         super().__init__(
             custom_id="points",
@@ -82,7 +82,7 @@ class StartedGameSelect(ui.Select[StartedGameView]):
             ],
         )
 
-    async def callback(self, interaction: discord.Interaction):
+    async def callback(self, interaction: discord.Interaction) -> None:
         from ..actions import LookingForGameAction
 
         with tracer.trace(name="interaction", resource="points"):  # type: ignore

--- a/src/spellbot/web/server.py
+++ b/src/spellbot/web/server.py
@@ -10,9 +10,9 @@ from ..logs import configure_logging
 
 configure_logging(getenv("LOG_LEVEL") or "INFO")
 
-from ..database import initialize_connection
-from ..environment import running_in_pytest
-from . import build_web_app
+from ..database import initialize_connection  # noqa: E402
+from ..environment import running_in_pytest  # noqa: E402
+from . import build_web_app  # noqa: E402
 
 if not running_in_pytest():  # pragma: no cover
     load_dotenv()

--- a/tests/actions/test_tasks_aciton.py
+++ b/tests/actions/test_tasks_aciton.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import discord
 import pytest
 import pytest_asyncio
+import pytz
 from pytest_mock import MockerFixture
 from spellbot import SpellBot
 from spellbot.actions import TasksAction
@@ -124,7 +125,7 @@ async def bot(mocker: MockerFixture, discord_guild: discord.Guild) -> SpellBot:
     return build_bot(mock_games=True, create_connection=False)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestTaskCleanupOldVoiceChannels:
     async def test_when_nothing_exists(
         self,
@@ -214,13 +215,13 @@ class TestTaskCleanupOldVoiceChannels:
         action: TasksAction,
     ) -> None:
         manage_perms = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         voice_channel = make_voice_channel(
             id=4001,
             name=f"Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
         )
         make_category_channel(
             id=3001,
@@ -244,13 +245,13 @@ class TestTaskCleanupOldVoiceChannels:
         action: TasksAction,
     ) -> None:
         manage_perms = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         voice_channel = make_voice_channel(
             id=4001,
             name=f"Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow() - timedelta(hours=1),
+            created_at=datetime.now(tz=pytz.utc) - timedelta(hours=1),
         )
         voice_channel.voice_states.keys = lambda: True  # type: ignore
         make_category_channel(
@@ -279,7 +280,7 @@ class TestTaskCleanupOldVoiceChannels:
             id=4001,
             name=f"Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow() - timedelta(hours=1),
+            created_at=datetime.now(tz=pytz.utc) - timedelta(hours=1),
         )
         voice_channel.voice_states.keys = lambda: False  # type: ignore
         make_category_channel(
@@ -304,13 +305,13 @@ class TestTaskCleanupOldVoiceChannels:
         action: TasksAction,
     ) -> None:
         manage_perms = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         voice_channel = make_voice_channel(
             id=4001,
             name=f"XXX-Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow() - timedelta(hours=1),
+            created_at=datetime.now(tz=pytz.utc) - timedelta(hours=1),
         )
         game.voice_xid = voice_channel.id  # type: ignore
         DatabaseSession.commit()
@@ -336,13 +337,13 @@ class TestTaskCleanupOldVoiceChannels:
         action: TasksAction,
     ) -> None:
         manage_perms = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         voice_channel = make_voice_channel(
             id=4001,
             name=f"XXX-Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow() - timedelta(hours=1),
+            created_at=datetime.now(tz=pytz.utc) - timedelta(hours=1),
         )
         game.voice_xid = voice_channel.id + 1  # type: ignore
         DatabaseSession.commit()
@@ -368,13 +369,13 @@ class TestTaskCleanupOldVoiceChannels:
         action: TasksAction,
     ) -> None:
         manage_perms = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         voice_channel = make_voice_channel(
             id=4001,
             name=f"Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow() - timedelta(days=1),
+            created_at=datetime.now(tz=pytz.utc) - timedelta(days=1),
         )
         voice_channel.voice_states.keys = lambda: True  # type: ignore
         make_category_channel(
@@ -399,13 +400,13 @@ class TestTaskCleanupOldVoiceChannels:
         action: TasksAction,
     ) -> None:
         manage_perms = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         voice_channel = make_voice_channel(
             id=4001,
             name=f"Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow() - timedelta(hours=1),
+            created_at=datetime.now(tz=pytz.utc) - timedelta(hours=1),
         )
         voice_channel.voice_states.keys = lambda: False  # type: ignore
         make_category_channel(
@@ -434,13 +435,13 @@ class TestTaskCleanupOldVoiceChannels:
 
         mocker.patch.object(mod.settings, "VOICE_CLEANUP_BATCH", 0)
         manage_perms = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         voice_channel = make_voice_channel(
             id=4001,
             name=f"Game-SB{game.id}",
             perms=manage_perms,
-            created_at=datetime.utcnow() - timedelta(hours=1),
+            created_at=datetime.now(tz=pytz.utc) - timedelta(hours=1),
         )
         voice_channel.voice_states.keys = lambda: False  # type: ignore
         make_category_channel(

--- a/tests/cogs/test_about_cog.py
+++ b/tests/cogs/test_about_cog.py
@@ -7,7 +7,7 @@ from spellbot.cogs import AboutCog
 from tests.mixins import InteractionMixin
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogAbout(InteractionMixin):
     async def test_about(self) -> None:
         cog = AboutCog(self.bot)

--- a/tests/cogs/test_block_cog.py
+++ b/tests/cogs/test_block_cog.py
@@ -17,9 +17,9 @@ async def cog(bot: SpellBot) -> BlockCog:
     return BlockCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogBlock(InteractionMixin):
-    async def test_block_and_unblock(self, cog: BlockCog):
+    async def test_block_and_unblock(self, cog: BlockCog) -> None:
         target = MagicMock()
         target.id = 2
         target.display_name = "target-author-display-name"
@@ -31,7 +31,7 @@ class TestCogBlock(InteractionMixin):
             ephemeral=True,
         )
 
-        users = sorted(list(DatabaseSession.query(User).all()), key=lambda u: u.name)
+        users = sorted(DatabaseSession.query(User).all(), key=lambda u: u.name)
         assert len(users) == 2
         assert users[0].name == target.display_name
         assert users[0].xid == target.id
@@ -48,7 +48,7 @@ class TestCogBlock(InteractionMixin):
         blocks = list(DatabaseSession.query(Block).all())
         assert len(blocks) == 0
 
-    async def test_block_self(self, cog: BlockCog):
+    async def test_block_self(self, cog: BlockCog) -> None:
         target = MagicMock()
         target.id = self.interaction.user.id
         target.display_name = self.interaction.user.display_name

--- a/tests/cogs/test_config_cog.py
+++ b/tests/cogs/test_config_cog.py
@@ -11,14 +11,14 @@ from tests.mixins import InteractionMixin
 from tests.mocks import mock_operations
 
 
-@pytest.fixture
+@pytest.fixture()
 def cog(bot: SpellBot) -> ConfigCog:
     return ConfigCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogConfig(InteractionMixin):
-    async def test_power_level(self, cog: ConfigCog):
+    async def test_power_level(self, cog: ConfigCog) -> None:
         await self.run(cog.power, level=10)
 
         config = DatabaseSession.query(Config).one()
@@ -28,9 +28,9 @@ class TestCogConfig(InteractionMixin):
         assert config.power_level == 10
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogConfigPowerLevelWhenUserWaiting(InteractionMixin):
-    async def test_happy_path(self, cog: ConfigCog, player: User):
+    async def test_happy_path(self, cog: ConfigCog, player: User) -> None:
         with mock_operations(config_action):
             config_action.safe_fetch_text_channel.return_value = self.interaction.channel
             config_action.safe_get_partial_message.return_value = self.interaction.message
@@ -62,7 +62,7 @@ class TestCogConfigPowerLevelWhenUserWaiting(InteractionMixin):
                 "type": "rich",
             }
 
-    async def test_when_channel_not_found(self, cog: ConfigCog, player: User):
+    async def test_when_channel_not_found(self, cog: ConfigCog, player: User) -> None:
         with mock_operations(config_action):
             config_action.safe_fetch_text_channel.return_value = None
 
@@ -70,7 +70,7 @@ class TestCogConfigPowerLevelWhenUserWaiting(InteractionMixin):
 
             config_action.safe_update_embed.assert_not_called()
 
-    async def test_when_message_not_found(self, cog: ConfigCog, player: User):
+    async def test_when_message_not_found(self, cog: ConfigCog, player: User) -> None:
         with mock_operations(config_action):
             config_action.safe_fetch_text_channel.return_value = self.interaction.channel
             config_action.safe_get_partial_message.return_value = None

--- a/tests/cogs/test_events_cog.py
+++ b/tests/cogs/test_events_cog.py
@@ -14,12 +14,12 @@ from tests.mixins import InteractionMixin
 from tests.mocks import mock_discord_object, mock_operations
 
 
-@pytest.fixture
+@pytest.fixture()
 def cog(bot: SpellBot) -> EventsCog:
     return EventsCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogEvents(InteractionMixin):
     async def test_game(
         self,
@@ -42,7 +42,8 @@ class TestCogEvents(InteractionMixin):
         game = DatabaseSession.query(Game).one()
         assert game.status == GameStatus.STARTED.value
         admin = DatabaseSession.query(User).get(self.interaction.user.id)
-        assert admin is not None and admin.game_id is None
+        assert admin is not None
+        assert admin.game_id is None
         players = DatabaseSession.query(User).filter(User.xid != self.interaction.user.id).all()
         assert len(players) == 2
         for player in players:

--- a/tests/cogs/test_leave_cog.py
+++ b/tests/cogs/test_leave_cog.py
@@ -18,7 +18,7 @@ async def cog(bot: SpellBot) -> LeaveGameCog:
     return LeaveGameCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogLeaveGame(InteractionMixin):
     async def test_leave(self, cog: LeaveGameCog, message: discord.Message, player: User) -> None:
         with mock_operations(leave_action):

--- a/tests/cogs/test_lfg_cog.py
+++ b/tests/cogs/test_lfg_cog.py
@@ -15,14 +15,14 @@ from tests.mixins import InteractionMixin
 from tests.mocks import mock_discord_object, mock_operations
 
 
-@pytest.fixture
+@pytest.fixture()
 def cog(bot: SpellBot) -> LookingForGameCog:
     return LookingForGameCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogLookingForGame(InteractionMixin):
-    async def test_lfg(self, cog: LookingForGameCog, channel: Channel):
+    async def test_lfg(self, cog: LookingForGameCog, channel: Channel) -> None:
         await self.run(cog.lfg)
         game = DatabaseSession.query(Game).one()
         user = DatabaseSession.query(User).one()
@@ -34,7 +34,7 @@ class TestCogLookingForGame(InteractionMixin):
         self,
         cog: LookingForGameCog,
         add_channel: Callable[..., Channel],
-    ):
+    ) -> None:
         channel = add_channel(default_seats=2, xid=self.interaction.channel_id)
         game = self.factories.game.create(
             guild=self.guild,
@@ -227,7 +227,7 @@ class TestCogLookingForGame(InteractionMixin):
 #             assert game.message_xid is None
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGameCrossContext(BaseMixin):
 #     # TODO: Refactor.
 #     @pytest.mark.skip(reason="needs refactoring")
@@ -341,7 +341,7 @@ class TestCogLookingForGame(InteractionMixin):
 #         }
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGameJoinButton(ComponentContextMixin):
 #     async def test_join(self):
 #         assert self.ctx.author
@@ -519,7 +519,7 @@ class TestCogLookingForGame(InteractionMixin):
 #             }
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGameUserNotifications(InteractionContextMixin):
 #     async def test_happy_path(self):
 #         assert self.ctx.author
@@ -631,7 +631,7 @@ class TestCogLookingForGame(InteractionMixin):
 #             # )
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGameUserAwards(InteractionContextMixin):
 #     async def test_happy_path(self):
 #         assert self.ctx.author
@@ -707,7 +707,7 @@ class TestCogLookingForGame(InteractionMixin):
 #             assert award.guild_award_id == guild_award.id
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGameWatchedUsers(InteractionContextMixin):
 #     async def test_happy_path(self, monkeypatch):
 #         assert self.ctx.guild
@@ -791,7 +791,7 @@ class TestCogLookingForGame(InteractionMixin):
 #             lfg_action.safe_send_user.assert_not_called()
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGameLeaveButton(ComponentContextMixin):
 #     async def test_leave(self):
 #         assert self.ctx.author
@@ -874,7 +874,7 @@ class TestCogLookingForGame(InteractionMixin):
 #             )
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGameVoiceCreate(ComponentContextMixin):
 #     async def test_join_happy_path(self):
 #         assert self.ctx.guild

--- a/tests/cogs/test_lfg_cog_concurrency.py
+++ b/tests/cogs/test_lfg_cog_concurrency.py
@@ -26,9 +26,9 @@ async def run_lfg(cog: LookingForGameCog, interaction: discord.Interaction) -> N
     return await callback(interaction=interaction)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogLookingForGameConcurrency:
-    async def test_concurrent_lfg_requests_different_channels(self, bot: SpellBot):
+    async def test_concurrent_lfg_requests_different_channels(self, bot: SpellBot) -> None:
         cog = LookingForGameCog(bot)
         guild = build_guild()
         n = 100
@@ -61,10 +61,10 @@ class TestCogLookingForGameConcurrency:
         self,
         bot: SpellBot,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         next_message_xid = 1
 
-        def get_next_message(*args: Any, **kwargs: Any):
+        def get_next_message(*args: Any, **kwargs: Any) -> discord.Message:
             nonlocal next_message_xid
             message = MagicMock(spec=discord.Message)
             message.id = next_message_xid

--- a/tests/cogs/test_lfg_cog_points.py
+++ b/tests/cogs/test_lfg_cog_points.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 # from tests.mocks import mock_discord_user, mock_operations
 
 
-# @pytest.mark.asyncio
+# @pytest.mark.asyncio()
 # class TestCogLookingForGamePoints:
 #     async def test_points(
 #         self,

--- a/tests/cogs/test_owner_cog.py
+++ b/tests/cogs/test_owner_cog.py
@@ -15,7 +15,7 @@ from spellbot.models import User
 from tests.mixins import ContextMixin
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogOwner(ContextMixin):
     async def run(
         self,
@@ -96,6 +96,6 @@ class TestCogOwner(ContextMixin):
                     guilds:   0
                     users:    0
                     ```
-                """
-            )
+                """,
+            ),
         )

--- a/tests/cogs/test_score_cog.py
+++ b/tests/cogs/test_score_cog.py
@@ -6,6 +6,7 @@ from typing import Callable, cast
 import discord
 import pytest
 import pytest_asyncio
+import pytz
 from freezegun.api import FrozenDateTimeFactory
 from spellbot import SpellBot
 from spellbot.cogs import ScoreCog
@@ -20,7 +21,7 @@ async def cog(bot: SpellBot) -> ScoreCog:
     return ScoreCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogScore(InteractionMixin):
     async def test_score(self, cog: ScoreCog, user: User, channel: Channel) -> None:
         await self.run(cog.score)
@@ -128,7 +129,7 @@ class TestCogScore(InteractionMixin):
         add_user: Callable[..., User],
         freezer: FrozenDateTimeFactory,
     ) -> None:
-        now = datetime(2020, 1, 1)
+        now = datetime(2020, 1, 1, tzinfo=pytz.utc)
         freezer.move_to(now)
 
         user1 = add_user()

--- a/tests/cogs/test_sync_cog.py
+++ b/tests/cogs/test_sync_cog.py
@@ -11,7 +11,7 @@ from spellbot.cogs import SyncCog
 from tests.mixins import ContextMixin
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogSync(ContextMixin):
     async def test_sync(self, mocker: MockerFixture) -> None:
         mocker.patch("spellbot.cogs.sync_cog.load_extensions", AsyncMock())

--- a/tests/cogs/test_verify_cog.py
+++ b/tests/cogs/test_verify_cog.py
@@ -19,13 +19,13 @@ async def cog(bot: SpellBot) -> VerifyCog:
     return VerifyCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogVerify(InteractionMixin):
     @pytest_asyncio.fixture
     async def target(self, add_user: Callable[..., User]) -> discord.Member:
         return cast(discord.Member, mock_discord_object(add_user()))
 
-    async def test_verify_and_unverify(self, cog: VerifyCog, target: discord.Member):
+    async def test_verify_and_unverify(self, cog: VerifyCog, target: discord.Member) -> None:
         await self.run(cog.verify, target=target)
 
         self.interaction.response.send_message.assert_called_once_with(

--- a/tests/cogs/test_watch_cog.py
+++ b/tests/cogs/test_watch_cog.py
@@ -13,12 +13,12 @@ from tests.mixins import InteractionMixin
 from tests.mocks import mock_discord_object
 
 
-@pytest.fixture
+@pytest.fixture()
 def cog(bot: SpellBot) -> WatchCog:
     return WatchCog(bot)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestCogWatch(InteractionMixin):
     async def test_watch_and_unwatch(self, cog: WatchCog, add_user: Callable[..., User]) -> None:
         target_user = add_user()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
+import pytest
 from _pytest.config import Config
-from pytest import Item, Session
-
-# Make all fixtures available to all tests
-from .fixtures import *  # noqa
 
 # Ensure that some suites run last and in order, any unspecified suites will before
 SUITE_ORDER = [
@@ -12,8 +9,12 @@ SUITE_ORDER = [
 ]
 
 
-def pytest_collection_modifyitems(session: Session, config: Config, items: list[Item]):
-    def order(item: Item):
+def pytest_collection_modifyitems(
+    session: pytest.Session,
+    config: Config,
+    items: list[pytest.Item],
+) -> None:
+    def order(item: pytest.Item) -> int:
         if not item:  # pragma: no cover
             return 0
         cls = getattr(item, "cls", None)
@@ -25,8 +26,13 @@ def pytest_collection_modifyitems(session: Session, config: Config, items: list[
     items.sort(key=order)
 
 
-def pytest_configure(config: Config):
+def pytest_configure(config: Config) -> None:
     config.addinivalue_line(
         "markers",
         "nosession: mark test to run without a database session",
     )
+
+
+pytest_plugins = [
+    "tests.fixtures",
+]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -54,7 +54,7 @@ class Factories:
     watch = WatchFactory
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture()
 async def factories() -> Factories:
     return Factories()
 
@@ -82,7 +82,7 @@ async def session_context(
         VerifyFactory._meta.sqlalchemy_session = DatabaseSession  # type: ignore
         WatchFactory._meta.sqlalchemy_session = DatabaseSession  # type: ignore
 
-        def cleanup_session():
+        def cleanup_session() -> None:
             async def finalizer() -> None:
                 try:
                     await rollback_transaction()
@@ -95,7 +95,7 @@ async def session_context(
 
     context = contextvars.copy_context()
 
-    def cleanup_context():
+    def cleanup_context() -> None:
         nonlocal context
         for c in context:
             c.set(context[c])
@@ -117,7 +117,7 @@ async def bot() -> SpellBot:
     return build_bot(mock_games=True, create_connection=False)
 
 
-@pytest.fixture
+@pytest.fixture()
 def client(
     loop: AbstractEventLoop,
     aiohttp_client: Callable[..., Awaitable[TestClient]],
@@ -126,47 +126,47 @@ def client(
     return loop.run_until_complete(aiohttp_client(app))
 
 
-@pytest.fixture
+@pytest.fixture()
 def settings() -> Settings:
     return Settings()
 
 
-@pytest.fixture
+@pytest.fixture()
 def guild(factories: Factories) -> Guild:
     return factories.guild.create()
 
 
-@pytest.fixture
+@pytest.fixture()
 def channel(factories: Factories, guild: Guild) -> Channel:
     return factories.channel.create(guild=guild)
 
 
-@pytest.fixture
+@pytest.fixture()
 def game(factories: Factories, guild: Guild, channel: Channel) -> Game:
     return factories.game.create(guild=guild, channel=channel)
 
 
-@pytest.fixture
+@pytest.fixture()
 def user(factories: Factories) -> Game:
     return factories.user.create()
 
 
-@pytest.fixture
+@pytest.fixture()
 def dpy_author() -> discord.User:
     return build_author()
 
 
-@pytest.fixture
+@pytest.fixture()
 def dpy_guild() -> discord.Guild:
     return build_guild()
 
 
-@pytest.fixture
+@pytest.fixture()
 def dpy_channel(dpy_guild: discord.Guild) -> discord.TextChannel:
     return build_channel(dpy_guild)
 
 
-@pytest.fixture
+@pytest.fixture()
 def dpy_message(
     dpy_guild: discord.Guild,
     dpy_channel: discord.TextChannel,
@@ -175,7 +175,7 @@ def dpy_message(
     return build_message(dpy_guild, dpy_channel, dpy_author)
 
 
-@pytest.fixture
+@pytest.fixture()
 def interaction(
     dpy_guild: discord.Guild,
     dpy_channel: discord.TextChannel,
@@ -184,7 +184,7 @@ def interaction(
     return build_interaction(dpy_guild, dpy_channel, dpy_author)
 
 
-@pytest.fixture
+@pytest.fixture()
 def context(
     dpy_guild: discord.Guild,
     dpy_channel: discord.TextChannel,
@@ -200,7 +200,7 @@ def context(
     return stub
 
 
-@pytest.fixture
+@pytest.fixture()
 def cli() -> Generator[MagicMock, None, None]:
     with (
         patch("spellbot.cli.asyncio") as mock_asyncio,
@@ -238,6 +238,6 @@ def cli() -> Generator[MagicMock, None, None]:
         yield obj
 
 
-@pytest.fixture
+@pytest.fixture()
 def runner() -> CliRunner:
     return CliRunner()

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -24,7 +24,7 @@ class MockClient:
         guilds: Optional[list[discord.Guild]] = None,
         users: Optional[list[discord.User]] = None,
         categories: Optional[list[discord.CategoryChannel]] = None,
-    ):
+    ) -> None:
         self.user = user
         self.channels = channels or []
         self.guilds = guilds or []
@@ -104,7 +104,7 @@ def mock_operations(
             elif name.startswith("safe_"):  # all others we can assume are async
                 if name == "safe_fetch_user":
 
-                    async def finder(_, xid: int):
+                    async def finder(_: Any, xid: int) -> Optional[discord.User]:
                         return next((user for user in _users if user.id == xid), None)
 
                     monkeypatch.setattr(module, name, AsyncMock(side_effect=finder))
@@ -158,6 +158,7 @@ def build_channel(guild: discord.Guild, offset: int = 1) -> discord.TextChannel:
     channel.guild = guild
     channel.type = discord.ChannelType.text
     channel.permissions_for = MagicMock(return_value=discord.Permissions())
+    channel.is_set = False
     return channel
 
 

--- a/tests/models/test_award.py
+++ b/tests/models/test_award.py
@@ -4,7 +4,7 @@ from tests.fixtures import Factories
 
 
 class TestModelAward:
-    def test_award(self, factories: Factories):
+    def test_award(self, factories: Factories) -> None:
         guild = factories.guild.create()
         guild_award = factories.guild_award.create(guild=guild)
 

--- a/tests/models/test_block.py
+++ b/tests/models/test_block.py
@@ -4,7 +4,7 @@ from tests.fixtures import Factories
 
 
 class TestModelBlock:
-    def test_block(self, factories: Factories):
+    def test_block(self, factories: Factories) -> None:
         user1 = factories.user.create()
         user2 = factories.user.create()
         block = factories.block.create(user_xid=user1.xid, blocked_user_xid=user2.xid)

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -4,7 +4,7 @@ from tests.fixtures import Factories
 
 
 class TestModelChannel:
-    def test_channel(self, factories: Factories):
+    def test_channel(self, factories: Factories) -> None:
         guild = factories.guild.create()
         channel = factories.channel.create(guild=guild)
 

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -4,7 +4,7 @@ from tests.fixtures import Factories
 
 
 class TestModelConfig:
-    def test_config(self, factories: Factories):
+    def test_config(self, factories: Factories) -> None:
         guild = factories.guild.create()
         user = factories.user.create()
         config = factories.config.create(guild_xid=guild.xid, user_xid=user.xid)

--- a/tests/models/test_game.py
+++ b/tests/models/test_game.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytz
 from spellbot.models import GameStatus
 from spellbot.settings import Settings
 
@@ -9,7 +10,7 @@ from tests.fixtures import Factories
 
 
 class TestModelGame:
-    def test_game_to_dict(self, factories: Factories):
+    def test_game_to_dict(self, factories: Factories) -> None:
         guild = factories.guild.create()
         channel = factories.channel.create(guild=guild)
         game = factories.game.create(guild=guild, channel=channel)
@@ -33,7 +34,7 @@ class TestModelGame:
             "spectate_link": game.spectate_link,
         }
 
-    def test_game_show_links(self, factories: Factories):
+    def test_game_show_links(self, factories: Factories) -> None:
         guild1 = factories.guild.create()
         guild2 = factories.guild.create(show_links=True)
         channel1 = factories.channel.create(guild=guild1)
@@ -46,7 +47,7 @@ class TestModelGame:
         assert game2.show_links()
         assert game2.show_links(True)
 
-    def test_game_embed_empty(self, settings: Settings, factories: Factories):
+    def test_game_embed_empty(self, settings: Settings, factories: Factories) -> None:
         guild = factories.guild.create(motd=None)
         channel = factories.channel.create(guild=guild, motd=None)
         game = factories.game.create(guild=guild, channel=channel)
@@ -63,7 +64,7 @@ class TestModelGame:
             "type": "rich",
         }
 
-    def test_game_embed_pending(self, settings: Settings, factories: Factories):
+    def test_game_embed_pending(self, settings: Settings, factories: Factories) -> None:
         guild = factories.guild.create(motd=None)
         channel = factories.channel.create(guild=guild, motd=None)
         game = factories.game.create(guild=guild, channel=channel)
@@ -84,7 +85,7 @@ class TestModelGame:
             "type": "rich",
         }
 
-    def test_game_embed_placeholders(self, settings: Settings, factories: Factories):
+    def test_game_embed_placeholders(self, settings: Settings, factories: Factories) -> None:
         guild = factories.guild.create(motd="player 1: ${player_name_1}")
         channel = factories.channel.create(guild=guild, motd="game id: ${game_id}")
         game = factories.game.create(guild=guild, channel=channel)
@@ -113,7 +114,7 @@ class TestModelGame:
         self,
         settings: Settings,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(motd=None)
         channel = factories.channel.create(guild=guild, motd=None)
         game = factories.game.create(guild=guild, channel=channel)
@@ -147,13 +148,13 @@ class TestModelGame:
         self,
         settings: Settings,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(motd=None)
         channel = factories.channel.create(guild=guild, motd=None)
         game = factories.game.create(
             seats=2,
             status=GameStatus.STARTED.value,
-            started_at=datetime(2021, 10, 31),
+            started_at=datetime(2021, 10, 31, tzinfo=pytz.utc),
             spelltable_link="https://spelltable/link",
             guild=guild,
             channel=channel,
@@ -208,13 +209,13 @@ class TestModelGame:
         self,
         settings: Settings,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(motd=None)
         channel = factories.channel.create(guild=guild, show_points=True, motd=None)
         game = factories.game.create(
             seats=2,
             status=GameStatus.STARTED.value,
-            started_at=datetime(2021, 10, 31),
+            started_at=datetime(2021, 10, 31, tzinfo=pytz.utc),
             guild=guild,
             channel=channel,
         )
@@ -249,13 +250,13 @@ class TestModelGame:
         self,
         settings: Settings,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(motd=None)
         channel = factories.channel.create(guild=guild, motd=None)
         game = factories.game.create(
             seats=2,
             status=GameStatus.STARTED.value,
-            started_at=datetime(2021, 10, 31),
+            started_at=datetime(2021, 10, 31, tzinfo=pytz.utc),
             guild=guild,
             channel=channel,
         )
@@ -309,13 +310,13 @@ class TestModelGame:
         self,
         settings: Settings,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(motd=None)
         channel = factories.channel.create(guild=guild, motd=None)
         game = factories.game.create(
             seats=2,
             status=GameStatus.STARTED.value,
-            started_at=datetime(2021, 10, 31),
+            started_at=datetime(2021, 10, 31, tzinfo=pytz.utc),
             spelltable_link="https://spelltable/link",
             voice_invite_link="https://voice/invite/link",
             voice_xid=501,
@@ -376,13 +377,13 @@ class TestModelGame:
             "type": "rich",
         }
 
-    def test_game_embed_started_with_motd(self, settings: Settings, factories: Factories):
+    def test_game_embed_started_with_motd(self, settings: Settings, factories: Factories) -> None:
         guild = factories.guild.create(motd="this is a message of the day")
         channel = factories.channel.create(guild=guild, motd=None)
         game = factories.game.create(
             seats=2,
             status=GameStatus.STARTED.value,
-            started_at=datetime(2021, 10, 31),
+            started_at=datetime(2021, 10, 31, tzinfo=pytz.utc),
             spelltable_link="https://spelltable/link",
             guild=guild,
             channel=channel,

--- a/tests/models/test_guild.py
+++ b/tests/models/test_guild.py
@@ -4,7 +4,7 @@ from tests.fixtures import Factories
 
 
 class TestModelGuild:
-    def test_guild(self, factories: Factories):
+    def test_guild(self, factories: Factories) -> None:
         guild = factories.guild.create()
         channel1 = factories.channel.create(guild=guild)
         channel2 = factories.channel.create(guild=guild)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -6,7 +6,7 @@ from tests.fixtures import Factories
 
 
 class TestModelUser:
-    def test_user(self, factories: Factories):
+    def test_user(self, factories: Factories) -> None:
         guild = factories.guild.create()
         channel = factories.channel.create(guild=guild)
         game1 = factories.game.create(guild=guild, channel=channel)

--- a/tests/models/test_watch.py
+++ b/tests/models/test_watch.py
@@ -4,7 +4,7 @@ from tests.fixtures import Factories
 
 
 class TestModelWatch:
-    def test_watch(self, factories: Factories):
+    def test_watch(self, factories: Factories) -> None:
         guild = factories.guild.create()
         user = factories.user.create()
         watch = factories.watch.create(

--- a/tests/services/test_awards.py
+++ b/tests/services/test_awards.py
@@ -7,14 +7,14 @@ from spellbot.services import AwardsService, NewAward
 from tests.fixtures import Factories
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceAwards:
     async def test_give_awards_first_award(
         self,
         guild: Guild,
         channel: Channel,
         factories: Factories,
-    ):
+    ) -> None:
         factories.guild_award.create(guild=guild, count=1, role="one", message="msg")
         game = factories.game.create(guild=guild, channel=channel)
         user = factories.user.create()
@@ -33,7 +33,7 @@ class TestServiceAwards:
         guild: Guild,
         channel: Channel,
         factories: Factories,
-    ):
+    ) -> None:
         user = factories.user.create()
         factories.guild_award.create(guild=guild, count=1, role="one", message="msg")
         factories.user_award.create(
@@ -56,7 +56,7 @@ class TestServiceAwards:
         guild: Guild,
         channel: Channel,
         factories: Factories,
-    ):
+    ) -> None:
         game = factories.game.create(guild=guild, channel=channel)
         factories.guild_award.create(guild=guild, count=1, role="one", message="msg")
         user = factories.user.create(game=game)
@@ -74,7 +74,7 @@ class TestServiceAwards:
         guild: Guild,
         channel: Channel,
         factories: Factories,
-    ):
+    ) -> None:
         factories.guild_award.create(guild=guild, count=2, role="two", message="msg")
         game = factories.game.create(guild=guild, channel=channel)
         user = factories.user.create()
@@ -93,7 +93,7 @@ class TestServiceAwards:
         guild: Guild,
         channel: Channel,
         factories: Factories,
-    ):
+    ) -> None:
         factories.guild_award.create(
             guild=guild,
             count=1,

--- a/tests/services/test_channels.py
+++ b/tests/services/test_channels.py
@@ -10,9 +10,9 @@ from spellbot.services import ChannelsService
 from tests.factories import ChannelFactory
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceChannels:
-    async def test_channels_upsert(self, guild: Guild):
+    async def test_channels_upsert(self, guild: Guild) -> None:
         channels = ChannelsService()
         discord_channel = MagicMock()
         discord_channel.id = 201
@@ -24,7 +24,8 @@ class TestServiceChannels:
 
         DatabaseSession.expire_all()
         channel = DatabaseSession.query(Channel).get(discord_channel.id)
-        assert channel and channel.xid == discord_channel.id
+        assert channel
+        assert channel.xid == discord_channel.id
         assert channel.name == "channel-name"
 
         discord_channel.name = "new-name"
@@ -32,22 +33,23 @@ class TestServiceChannels:
 
         DatabaseSession.expire_all()
         channel = DatabaseSession.query(Channel).get(discord_channel.id)
-        assert channel and channel.xid == discord_channel.id
+        assert channel
+        assert channel.xid == discord_channel.id
         assert channel.name == "new-name"
 
-    async def test_channels_select(self, guild: Guild):
+    async def test_channels_select(self, guild: Guild) -> None:
         channels = ChannelsService()
         assert not await channels.select(404)
 
         ChannelFactory.create(guild=guild, xid=404)
         assert await channels.select(404)
 
-    async def test_channels_current_default_seats(self, channel: Channel):
+    async def test_channels_current_default_seats(self, channel: Channel) -> None:
         channels = ChannelsService()
         data = await channels.select(channel.xid)
         assert data["default_seats"] == channel.default_seats
 
-    async def test_channels_set_default_seats(self, channel: Channel):
+    async def test_channels_set_default_seats(self, channel: Channel) -> None:
         channels = ChannelsService()
         data = await channels.select(channel.xid)
         assert data["default_seats"] != 2
@@ -56,28 +58,28 @@ class TestServiceChannels:
         data = await channels.select(channel.xid)
         assert data["default_seats"] == 2
 
-    async def test_channels_should_auto_verify(self, guild: Guild):
+    async def test_channels_should_auto_verify(self, guild: Guild) -> None:
         channel = ChannelFactory.create(guild=guild, auto_verify=True)
 
         channels = ChannelsService()
         data = await channels.select(channel.xid)
         assert data["auto_verify"]
 
-    async def test_channels_verified_only(self, guild: Guild):
+    async def test_channels_verified_only(self, guild: Guild) -> None:
         channel = ChannelFactory.create(guild=guild, verified_only=True)
 
         channels = ChannelsService()
         data = await channels.select(channel.xid)
         assert data["verified_only"]
 
-    async def test_channels_unverified_only(self, guild: Guild):
+    async def test_channels_unverified_only(self, guild: Guild) -> None:
         channel = ChannelFactory.create(guild=guild, unverified_only=True)
 
         channels = ChannelsService()
         data = await channels.select(channel.xid)
         assert data["unverified_only"]
 
-    async def test_channels_set_auto_verify(self, guild: Guild):
+    async def test_channels_set_auto_verify(self, guild: Guild) -> None:
         channel = ChannelFactory.create(guild=guild, auto_verify=False)
 
         channels = ChannelsService()
@@ -85,7 +87,7 @@ class TestServiceChannels:
         data = await channels.select(channel.xid)
         assert data["auto_verify"]
 
-    async def test_channels_set_verified_only(self, guild: Guild):
+    async def test_channels_set_verified_only(self, guild: Guild) -> None:
         channel = ChannelFactory.create(guild=guild, verified_only=False)
 
         channels = ChannelsService()
@@ -93,7 +95,7 @@ class TestServiceChannels:
         data = await channels.select(channel.xid)
         assert data["verified_only"]
 
-    async def test_channels_set_unverified_only(self, guild: Guild):
+    async def test_channels_set_unverified_only(self, guild: Guild) -> None:
         channel = ChannelFactory.create(guild=guild, unverified_only=False)
 
         channels = ChannelsService()
@@ -101,7 +103,7 @@ class TestServiceChannels:
         data = await channels.select(channel.xid)
         assert data["unverified_only"]
 
-    async def test_channels_set_motd(self, guild: Guild):
+    async def test_channels_set_motd(self, guild: Guild) -> None:
         channels = ChannelsService()
 
         channel = ChannelFactory.create(guild=guild, motd="whatever")
@@ -112,7 +114,7 @@ class TestServiceChannels:
         data = await channels.select(channel.xid)
         assert data["motd"] == "something else"
 
-    async def test_channels_set_delete_expired(self, guild: Guild):
+    async def test_channels_set_delete_expired(self, guild: Guild) -> None:
         channels = ChannelsService()
 
         channel = ChannelFactory.create(guild=guild, delete_expired=False)

--- a/tests/services/test_games.py
+++ b/tests/services/test_games.py
@@ -8,28 +8,28 @@ from spellbot.services import GamesService
 from tests.factories import BlockFactory, GameFactory, PlayFactory, UserFactory, WatchFactory
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceGames:
-    async def test_games_select(self, game: Game):
+    async def test_games_select(self, game: Game) -> None:
         games = GamesService()
         assert await games.select(game.id)
         assert not await games.select(404)
 
-    async def test_games_select_by_voice_xid(self, guild: Guild, channel: Channel):
+    async def test_games_select_by_voice_xid(self, guild: Guild, channel: Channel) -> None:
         game = GameFactory.create(guild=guild, channel=channel, voice_xid=12345)
 
         games = GamesService()
         assert await games.select_by_voice_xid(game.voice_xid)
         assert not await games.select_by_voice_xid(404)
 
-    async def test_games_select_by_message_xid(self, guild: Guild, channel: Channel):
+    async def test_games_select_by_message_xid(self, guild: Guild, channel: Channel) -> None:
         game = GameFactory.create(guild=guild, channel=channel)
 
         games = GamesService()
         assert await games.select_by_message_xid(game.message_xid)
         assert not await games.select_by_message_xid(404)
 
-    async def test_games_add_player(self, game: Game):
+    async def test_games_add_player(self, game: Game) -> None:
         user = UserFactory.create()
 
         games = GamesService()
@@ -38,9 +38,10 @@ class TestServiceGames:
 
         DatabaseSession.expire_all()
         found = DatabaseSession.query(User).get(user.xid)
-        assert found and found.game.id == game.id
+        assert found
+        assert found.game.id == game.id
 
-    async def test_games_to_embed(self, game: Game):
+    async def test_games_to_embed(self, game: Game) -> None:
         public_embed = game.to_embed().to_dict()
         private_embed = game.to_embed(True).to_dict()
 
@@ -49,16 +50,17 @@ class TestServiceGames:
         assert (await games.to_embed()).to_dict() == public_embed
         assert (await games.to_embed()).to_dict() == private_embed
 
-    async def test_games_set_message_xid(self, game: Game):
+    async def test_games_set_message_xid(self, game: Game) -> None:
         games = GamesService()
         await games.select(game.id)
         await games.set_message_xid(12345)
 
         DatabaseSession.expire_all()
         found = DatabaseSession.query(Game).filter_by(message_xid=12345).one_or_none()
-        assert found and found.id == game.id
+        assert found
+        assert found.id == game.id
 
-    async def test_games_fully_seated(self, guild: Guild, channel: Channel):
+    async def test_games_fully_seated(self, guild: Guild, channel: Channel) -> None:
         started_game = GameFactory.create(guild=guild, channel=channel)
         pending_game = GameFactory.create(guild=guild, channel=channel)
         for _ in range(started_game.seats):
@@ -71,17 +73,18 @@ class TestServiceGames:
         await games.select(pending_game.id)
         assert not await games.fully_seated()
 
-    async def test_games_make_ready(self, game: Game):
+    async def test_games_make_ready(self, game: Game) -> None:
         games = GamesService()
         await games.select(game.id)
         await games.make_ready("http://link")
 
         DatabaseSession.expire_all()
         found = DatabaseSession.query(Game).get(game.id)
-        assert found and found.spelltable_link == "http://link"
+        assert found
+        assert found.spelltable_link == "http://link"
         assert found.status == GameStatus.STARTED.value
 
-    async def test_games_player_xids(self, game: Game):
+    async def test_games_player_xids(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create(game=game)
 
@@ -89,7 +92,7 @@ class TestServiceGames:
         await games.select(game.id)
         assert set(await games.player_xids()) == {user1.xid, user2.xid}
 
-    async def test_games_watch_notes(self, game: Game):
+    async def test_games_watch_notes(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create(game=game)
         user3 = UserFactory.create()
@@ -102,25 +105,26 @@ class TestServiceGames:
             user1.xid: watch.note,
         }
 
-    async def test_games_set_voice(self, game: Game):
+    async def test_games_set_voice(self, game: Game) -> None:
         games = GamesService()
         await games.select(game.id)
         await games.set_voice(12345, "http://link")
 
         DatabaseSession.expire_all()
         found = DatabaseSession.query(Game).get(game.id)
-        assert found and found.voice_xid == 12345
+        assert found
+        assert found.voice_xid == 12345
         assert found.voice_invite_link == "http://link"
 
-    async def test_games_to_dict(self, game: Game):
+    async def test_games_to_dict(self, game: Game) -> None:
         games = GamesService()
         await games.select(game.id)
         assert await games.to_dict() == game.to_dict()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceGamesPlays:
-    async def test_games_players_included(self, game: Game):
+    async def test_games_players_included(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create()
         PlayFactory.create(user_xid=user1.xid, game_id=game.id)
@@ -130,7 +134,7 @@ class TestServiceGamesPlays:
         assert await games.players_included(user1.xid)
         assert not await games.players_included(user2.xid)
 
-    async def test_games_add_points(self, game: Game):
+    async def test_games_add_points(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create(game=game)
         PlayFactory.create(user_xid=user1.xid, game_id=game.id, points=5)
@@ -146,7 +150,7 @@ class TestServiceGamesPlays:
         found = DatabaseSession.query(Play).filter(Play.user_xid == user2.xid).one()
         assert found.points is None
 
-    async def test_games_record_plays(self, guild: Guild, channel: Channel):
+    async def test_games_record_plays(self, guild: Guild, channel: Channel) -> None:
         game = GameFactory.create(
             guild=guild,
             channel=channel,
@@ -162,16 +166,18 @@ class TestServiceGamesPlays:
 
         DatabaseSession.expire_all()
         found = DatabaseSession.query(Play).filter(Play.user_xid == user1.xid).one()
-        assert found.user_xid == user1.xid and found.game_id == game.id
+        assert found.user_xid == user1.xid
+        assert found.game_id == game.id
         found = DatabaseSession.query(Play).filter(Play.user_xid == user2.xid).one()
-        assert found.user_xid == user2.xid and found.game_id == game.id
+        assert found.user_xid == user2.xid
+        assert found.game_id == game.id
         found = DatabaseSession.query(Play).filter(Play.user_xid == 103).one_or_none()
         assert not found
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceGamesBlocked:
-    async def test_when_blocker_in_game(self, game: Game):
+    async def test_when_blocker_in_game(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create()
 
@@ -181,7 +187,7 @@ class TestServiceGamesBlocked:
         await games.select(game.id)
         assert await games.blocked(user2.xid)
 
-    async def test_when_blocker_outside_game(self, game: Game):
+    async def test_when_blocker_outside_game(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create()
 
@@ -191,7 +197,7 @@ class TestServiceGamesBlocked:
         await games.select(game.id)
         assert await games.blocked(user2.xid)
 
-    async def test_when_no_blockers(self, game: Game):
+    async def test_when_no_blockers(self, game: Game) -> None:
         UserFactory.create(game=game)
         user3 = UserFactory.create()
 
@@ -200,9 +206,9 @@ class TestServiceGamesBlocked:
         assert not await games.blocked(user3.xid)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceGamesFilterBlocked:
-    async def test_when_blocker_in_game(self, game: Game):
+    async def test_when_blocker_in_game(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create()
 
@@ -212,7 +218,7 @@ class TestServiceGamesFilterBlocked:
         await games.select(game.id)
         assert await games.filter_blocked_list(user2.xid, [user1.xid]) == []
 
-    async def test_when_blocker_outside_game(self, game: Game):
+    async def test_when_blocker_outside_game(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create()
 
@@ -222,7 +228,7 @@ class TestServiceGamesFilterBlocked:
         await games.select(game.id)
         assert await games.filter_blocked_list(user2.xid, [user1.xid]) == []
 
-    async def test_when_no_blockers(self, game: Game):
+    async def test_when_no_blockers(self, game: Game) -> None:
         UserFactory.create(game=game)
         user3 = UserFactory.create()
 
@@ -231,9 +237,9 @@ class TestServiceGamesFilterBlocked:
         assert await games.filter_blocked_list(user3.xid, [1, 2, 3]) == [1, 2, 3]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceGamesUpsert:
-    async def test_lfg_alone_when_existing_game(self, game: Game, user: User):
+    async def test_lfg_alone_when_existing_game(self, game: Game, user: User) -> None:
         games = GamesService()
         new = await games.upsert(
             guild_xid=game.guild.xid,
@@ -249,7 +255,7 @@ class TestServiceGamesUpsert:
         found = DatabaseSession.query(User).one()
         assert found.game_id == game.id
 
-    async def test_lfg_with_friend_when_existing_game(self, game: Game):
+    async def test_lfg_with_friend_when_existing_game(self, game: Game) -> None:
         user1 = UserFactory.create(xid=101)
         user2 = UserFactory.create(xid=102)
 
@@ -266,9 +272,9 @@ class TestServiceGamesUpsert:
 
         DatabaseSession.expire_all()
         rows = DatabaseSession.query(User.xid).filter(User.game_id == game.id).all()
-        assert set(row[0] for row in rows) == {101, 102}
+        assert {row[0] for row in rows} == {101, 102}
 
-    async def test_lfg_alone_when_no_game(self, guild: Guild, channel: Channel, user: User):
+    async def test_lfg_alone_when_no_game(self, guild: Guild, channel: Channel, user: User) -> None:
         games = GamesService()
         new = await games.upsert(
             guild_xid=guild.xid,
@@ -287,7 +293,7 @@ class TestServiceGamesUpsert:
         assert found_game.channel_xid == channel.xid
         assert found_user.game_id == found_game.id
 
-    async def test_lfg_with_friend_when_no_game(self, guild: Guild, channel: Channel):
+    async def test_lfg_with_friend_when_no_game(self, guild: Guild, channel: Channel) -> None:
         user1 = UserFactory.create(xid=101)
         user2 = UserFactory.create(xid=102)
 
@@ -307,9 +313,9 @@ class TestServiceGamesUpsert:
         assert game.guild_xid == guild.xid
         assert game.channel_xid == channel.xid
         rows = DatabaseSession.query(User.xid).filter(User.game_id == game.id).all()
-        assert set(row[0] for row in rows) == {101, 102}
+        assert {row[0] for row in rows} == {101, 102}
 
-    async def test_lfg_with_friend_when_full_game(self, guild: Guild, channel: Channel):
+    async def test_lfg_with_friend_when_full_game(self, guild: Guild, channel: Channel) -> None:
         user1 = UserFactory.create(xid=101)
         user2 = UserFactory.create(xid=102)
         user3 = UserFactory.create(xid=103)
@@ -331,9 +337,13 @@ class TestServiceGamesUpsert:
         assert game.guild_xid == guild.xid
         assert game.channel_xid == channel.xid
         rows = DatabaseSession.query(User.xid).filter(User.game_id == game.id).all()
-        assert set(row[0] for row in rows) == {101, 102, 103}
+        assert {row[0] for row in rows} == {101, 102, 103}
 
-    async def test_lfg_with_friend_when_game_wrong_format(self, guild: Guild, channel: Channel):
+    async def test_lfg_with_friend_when_game_wrong_format(
+        self,
+        guild: Guild,
+        channel: Channel,
+    ) -> None:
         user1 = UserFactory.create(xid=101)
         user2 = UserFactory.create(xid=102)
         user3 = UserFactory.create(xid=103)
@@ -360,4 +370,4 @@ class TestServiceGamesUpsert:
         assert game.guild_xid == guild.xid
         assert game.channel_xid == channel.xid
         rows = DatabaseSession.query(User.xid).filter(User.game_id == game.id).all()
-        assert set(row[0] for row in rows) == {101, 102, 103}
+        assert {row[0] for row in rows} == {101, 102, 103}

--- a/tests/services/test_guilds.py
+++ b/tests/services/test_guilds.py
@@ -10,9 +10,9 @@ from spellbot.services import GuildsService
 from tests.factories import GuildAwardFactory, GuildFactory
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceGuilds:
-    async def test_guilds_upsert(self):
+    async def test_guilds_upsert(self) -> None:
         discord_guild = MagicMock()
         discord_guild.id = 101
         discord_guild.name = "guild-name"
@@ -21,7 +21,8 @@ class TestServiceGuilds:
 
         DatabaseSession.expire_all()
         guild = DatabaseSession.query(Guild).get(discord_guild.id)
-        assert guild and guild.xid == discord_guild.id
+        assert guild
+        assert guild.xid == discord_guild.id
         assert guild.name == "guild-name"
 
         discord_guild.name = "new-name"
@@ -29,10 +30,11 @@ class TestServiceGuilds:
 
         DatabaseSession.expire_all()
         guild = DatabaseSession.query(Guild).get(discord_guild.id)
-        assert guild and guild.xid == discord_guild.id
+        assert guild
+        assert guild.xid == discord_guild.id
         assert guild.name == "new-name"
 
-    async def test_guilds_select(self):
+    async def test_guilds_select(self) -> None:
         guilds = GuildsService()
         assert not await guilds.select(404)
 
@@ -40,7 +42,7 @@ class TestServiceGuilds:
 
         assert await guilds.select(404)
 
-    async def test_guilds_should_voice_create(self):
+    async def test_guilds_should_voice_create(self) -> None:
         guild1 = GuildFactory.create()
         guild2 = GuildFactory.create(voice_create=True)
 
@@ -50,7 +52,7 @@ class TestServiceGuilds:
         await guilds.select(guild2.xid)
         assert await guilds.should_voice_create()
 
-    async def test_guilds_set_motd(self):
+    async def test_guilds_set_motd(self) -> None:
         guilds = GuildsService()
         assert not await guilds.select(101)
 
@@ -63,9 +65,10 @@ class TestServiceGuilds:
 
         DatabaseSession.expire_all()
         guild = DatabaseSession.query(Guild).get(guild.xid)
-        assert guild and guild.motd == message_of_the_day
+        assert guild
+        assert guild.motd == message_of_the_day
 
-    async def test_guilds_toggle_show_links(self):
+    async def test_guilds_toggle_show_links(self) -> None:
         guilds = GuildsService()
         assert not await guilds.select(101)
 
@@ -77,7 +80,8 @@ class TestServiceGuilds:
 
         DatabaseSession.expire_all()
         guild = DatabaseSession.query(Guild).get(101)
-        assert guild and guild.show_links
+        assert guild
+        assert guild.show_links
         DatabaseSession.expire_all()
 
         await guilds.select(101)
@@ -86,9 +90,10 @@ class TestServiceGuilds:
 
         DatabaseSession.expire_all()
         guild = DatabaseSession.query(Guild).get(101)
-        assert guild and not guild.show_links
+        assert guild
+        assert not guild.show_links
 
-    async def test_guilds_toggle_voice_create(self):
+    async def test_guilds_toggle_voice_create(self) -> None:
         guilds = GuildsService()
         assert not await guilds.select(101)
 
@@ -100,23 +105,25 @@ class TestServiceGuilds:
 
         DatabaseSession.expire_all()
         guild = DatabaseSession.query(Guild).get(101)
-        assert guild and guild.voice_create
+        assert guild
+        assert guild.voice_create
 
         await guilds.select(101)
         await guilds.toggle_voice_create()
 
         DatabaseSession.expire_all()
         guild = DatabaseSession.query(Guild).get(101)
-        assert guild and not guild.voice_create
+        assert guild
+        assert not guild.voice_create
 
-    async def test_guilds_current_name(self):
+    async def test_guilds_current_name(self) -> None:
         guild = GuildFactory.create(xid=101)
 
         guilds = GuildsService()
         await guilds.select(101)
         assert await guilds.current_name() == guild.name
 
-    async def test_guilds_voiced(self):
+    async def test_guilds_voiced(self) -> None:
         guilds = GuildsService()
         assert await guilds.voiced() == []
 
@@ -126,7 +133,7 @@ class TestServiceGuilds:
 
         assert set(await guilds.voiced()) == {guild1.xid, guild3.xid}
 
-    async def test_guilds_to_dict(self):
+    async def test_guilds_to_dict(self) -> None:
         guild = GuildFactory.create(xid=101)
 
         guilds = GuildsService()
@@ -134,7 +141,7 @@ class TestServiceGuilds:
         service_dict = await guilds.to_dict()
         assert guild.to_dict() == service_dict
 
-    async def test_guilds_award_add(self):
+    async def test_guilds_award_add(self) -> None:
         guilds = GuildsService()
         discord_guild = MagicMock()
         discord_guild.id = 101
@@ -158,7 +165,7 @@ class TestServiceGuilds:
         assert award.message == "a-message"
         assert award.guild_xid == discord_guild.id
 
-    async def test_guilds_award_delete(self, guild: Guild):
+    async def test_guilds_award_delete(self, guild: Guild) -> None:
         award1 = GuildAwardFactory.create(guild=guild)
         award2 = GuildAwardFactory.create(guild=guild)
 
@@ -172,7 +179,7 @@ class TestServiceGuilds:
         assert not DatabaseSession.query(GuildAward).get(award1_id)
         assert DatabaseSession.query(GuildAward).get(award2.id)
 
-    async def test_guilds_has_award_with_count(self, guild: Guild):
+    async def test_guilds_has_award_with_count(self, guild: Guild) -> None:
         award1 = GuildAwardFactory.create(guild=guild, count=10)
         award2 = GuildAwardFactory.create(guild=guild, count=20)
 

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -10,9 +10,9 @@ from spellbot.services import UsersService
 from tests.factories import UserFactory
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceUsers:
-    async def test_users_upsert(self):
+    async def test_users_upsert(self) -> None:
         user = UserFactory.create(xid=201)
 
         discord_user = MagicMock()
@@ -24,7 +24,8 @@ class TestServiceUsers:
 
         DatabaseSession.expire_all()
         user = DatabaseSession.query(User).get(discord_user.id)
-        assert user and user.xid == discord_user.id
+        assert user
+        assert user.xid == discord_user.id
         assert user.name == "user-name"
 
         discord_user.display_name = "new-name"
@@ -32,10 +33,11 @@ class TestServiceUsers:
 
         DatabaseSession.expire_all()
         user = DatabaseSession.query(User).get(discord_user.id)
-        assert user and user.xid == discord_user.id
+        assert user
+        assert user.xid == discord_user.id
         assert user.name == "new-name"
 
-    async def test_users_select(self):
+    async def test_users_select(self) -> None:
         users = UsersService()
         assert not await users.select(201)
 
@@ -44,7 +46,7 @@ class TestServiceUsers:
         DatabaseSession.expire_all()
         assert await users.select(201)
 
-    async def test_users_is_banned(self):
+    async def test_users_is_banned(self) -> None:
         user1 = UserFactory.create(banned=False)
         user2 = UserFactory.create(banned=True)
 
@@ -60,21 +62,21 @@ class TestServiceUsers:
         await users.select(user2.xid)
         assert await users.is_banned()
 
-    async def test_users_set_banned(self):
+    async def test_users_set_banned(self) -> None:
         user = UserFactory.create(banned=False)
 
         users = UsersService()
         await users.set_banned(True, user.xid)
         assert await users.is_banned(user.xid)
 
-    async def test_users_current_game_id(self, game: Game):
+    async def test_users_current_game_id(self, game: Game) -> None:
         user = UserFactory.create(game=game)
 
         users = UsersService()
         await users.select(user.xid)
         assert await users.current_game_id() == game.id
 
-    async def test_users_leave_game(self, game: Game):
+    async def test_users_leave_game(self, game: Game) -> None:
         user = UserFactory.create(game=game)
 
         users = UsersService()
@@ -82,7 +84,7 @@ class TestServiceUsers:
         await users.leave_game()
         assert await users.current_game_id() is None
 
-    async def test_users_is_waiting(self, game: Game):
+    async def test_users_is_waiting(self, game: Game) -> None:
         user1 = UserFactory.create(game=game)
         user2 = UserFactory.create()
 
@@ -92,7 +94,7 @@ class TestServiceUsers:
         await users.select(user2.xid)
         assert not await users.is_waiting()
 
-    async def test_users_block(self):
+    async def test_users_block(self) -> None:
         user1 = UserFactory.create()
         user2 = UserFactory.create()
 
@@ -103,7 +105,7 @@ class TestServiceUsers:
         blocks = [b.to_dict() for b in DatabaseSession.query(Block).all()]
         assert blocks == [{"user_xid": user1.xid, "blocked_user_xid": user2.xid}]
 
-    async def test_users_unblock(self):
+    async def test_users_unblock(self) -> None:
         user1 = UserFactory.create()
         user2 = UserFactory.create()
 
@@ -120,7 +122,7 @@ class TestServiceUsers:
         blocks = [b.to_dict() for b in DatabaseSession.query(Block).all()]
         assert blocks == []
 
-    async def test_users_watch(self, guild: Guild):
+    async def test_users_watch(self, guild: Guild) -> None:
         user = UserFactory.create()
 
         users = UsersService()
@@ -130,7 +132,7 @@ class TestServiceUsers:
         watches = [w.to_dict() for w in DatabaseSession.query(Watch).all()]
         assert watches == [{"guild_xid": guild.xid, "user_xid": user.xid, "note": "note"}]
 
-    async def test_users_watch_upsert(self, guild: Guild):
+    async def test_users_watch_upsert(self, guild: Guild) -> None:
         user = UserFactory.create()
 
         users = UsersService()
@@ -147,7 +149,7 @@ class TestServiceUsers:
             },
         ]
 
-    async def test_users_watch_without_note(self, guild: Guild):
+    async def test_users_watch_without_note(self, guild: Guild) -> None:
         user = UserFactory.create()
 
         users = UsersService()
@@ -157,7 +159,7 @@ class TestServiceUsers:
         watches = [w.to_dict() for w in DatabaseSession.query(Watch).all()]
         assert watches == [{"guild_xid": guild.xid, "user_xid": user.xid, "note": None}]
 
-    async def test_users_unwatch(self, guild: Guild):
+    async def test_users_unwatch(self, guild: Guild) -> None:
         user = UserFactory.create()
 
         users = UsersService()

--- a/tests/services/test_verifies.py
+++ b/tests/services/test_verifies.py
@@ -7,9 +7,9 @@ from spellbot.services import VerifiesService
 from tests.fixtures import Factories
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceVerifies:
-    async def test_verifies_upsert(self, guild: Guild, factories: Factories):
+    async def test_verifies_upsert(self, guild: Guild, factories: Factories) -> None:
         user = factories.user.create()
 
         verifies = VerifiesService()

--- a/tests/services/test_watches.py
+++ b/tests/services/test_watches.py
@@ -7,9 +7,9 @@ from spellbot.services import WatchesService
 from tests.factories import GuildFactory, UserFactory, WatchFactory
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestServiceWatches:
-    async def test_fetch(self):
+    async def test_fetch(self) -> None:
         guild1 = GuildFactory.create()
         guild2 = GuildFactory.create()
         user1 = UserFactory.create(xid=101)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -21,14 +21,18 @@ from spellbot.utils import handle_interaction_errors
 from .mixins import BaseMixin
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestSpellBot:
-    async def test_create_spelltable_link_mock(self, bot: SpellBot):
+    async def test_create_spelltable_link_mock(self, bot: SpellBot) -> None:
         link = await bot.create_spelltable_link()
         assert link is not None
         assert link.startswith("http://exmaple.com/game/")
 
-    async def test_create_spelltable_link(self, bot: SpellBot, monkeypatch: pytest.MonkeyPatch):
+    async def test_create_spelltable_link(
+        self,
+        bot: SpellBot,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         bot.mock_games = False
         generate_link_mock = AsyncMock(return_value="http://mock")
         monkeypatch.setattr(client, "generate_link", generate_link_mock)
@@ -37,7 +41,7 @@ class TestSpellBot:
         generate_link_mock.assert_called_once_with()
 
     @pytest.mark.parametrize(
-        "error, response",
+        ("error", "response"),
         [
             pytest.param(
                 app_commands.NoPrivateMessage(),
@@ -76,7 +80,7 @@ class TestSpellBot:
         interaction: discord.Interaction,
         error: Exception,
         response: str,
-    ):
+    ) -> None:
         await handle_interaction_errors(interaction, error)
         interaction.user.send.assert_called_once_with(response)
 
@@ -84,12 +88,16 @@ class TestSpellBot:
         self,
         interaction: discord.Interaction,
         caplog: pytest.LogCaptureFixture,
-    ):
+    ) -> None:
         await handle_interaction_errors(interaction, RuntimeError("test-bot-unhandled-exception"))
         assert "unhandled exception" in caplog.text
         assert "test-bot-unhandled-exception" in caplog.text
 
-    async def test_on_message_no_guild(self, bot: SpellBot, monkeypatch: pytest.MonkeyPatch):
+    async def test_on_message_no_guild(
+        self,
+        bot: SpellBot,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         super_on_message_mock = AsyncMock()
         monkeypatch.setattr(AutoShardedBot, "on_message", super_on_message_mock)
         message = MagicMock()
@@ -97,7 +105,11 @@ class TestSpellBot:
         await bot.on_message(message)
         super_on_message_mock.assert_called_once_with(message)
 
-    async def test_on_message_no_channel_type(self, bot: SpellBot, monkeypatch: pytest.MonkeyPatch):
+    async def test_on_message_no_channel_type(
+        self,
+        bot: SpellBot,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         super_on_message_mock = AsyncMock()
         monkeypatch.setattr(AutoShardedBot, "on_message", super_on_message_mock)
         message = MagicMock()
@@ -107,7 +119,7 @@ class TestSpellBot:
         await bot.on_message(message)
         super_on_message_mock.assert_not_called()
 
-    async def test_on_message_hidden(self, bot: SpellBot, monkeypatch: pytest.MonkeyPatch):
+    async def test_on_message_hidden(self, bot: SpellBot, monkeypatch: pytest.MonkeyPatch) -> None:
         super_on_message_mock = AsyncMock()
         monkeypatch.setattr(AutoShardedBot, "on_message", super_on_message_mock)
         message = MagicMock()
@@ -123,7 +135,7 @@ class TestSpellBot:
         dpy_message: discord.Message,
         bot: SpellBot,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         super_on_message_mock = AsyncMock()
         monkeypatch.setattr(AutoShardedBot, "on_message", super_on_message_mock)
         monkeypatch.setattr(bot, "handle_verification", AsyncMock())
@@ -134,9 +146,9 @@ class TestSpellBot:
         dpy_message.reply.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestSpellBotHandleVerification(BaseMixin):
-    async def test_missing_author_id(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_missing_author_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         message = MagicMock()
         message.guild = MagicMock()
         message.guild.id = 2
@@ -151,7 +163,7 @@ class TestSpellBotHandleVerification(BaseMixin):
 
         self.bot.handle_verification.assert_not_called()
 
-    async def test_without_auto_verify(self, dpy_message: discord.Message):
+    async def test_without_auto_verify(self, dpy_message: discord.Message) -> None:
         assert dpy_message.guild
         assert dpy_message.author
         assert isinstance(dpy_message.guild, discord.Guild)
@@ -166,7 +178,7 @@ class TestSpellBotHandleVerification(BaseMixin):
         assert found.user_xid == dpy_message.author.id
         assert not found.verified
 
-    async def test_with_auto_verify(self, dpy_message: discord.Message):
+    async def test_with_auto_verify(self, dpy_message: discord.Message) -> None:
         assert dpy_message.guild
         assert dpy_message.author
         assert isinstance(dpy_message.guild, discord.Guild)
@@ -188,7 +200,7 @@ class TestSpellBotHandleVerification(BaseMixin):
         assert found.user_xid == dpy_message.author.id
         assert found.verified
 
-    async def test_verified_only_when_unverified(self, dpy_message: discord.Message):
+    async def test_verified_only_when_unverified(self, dpy_message: discord.Message) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         self.factories.guild.create(xid=dpy_message.guild.id)
@@ -202,7 +214,7 @@ class TestSpellBotHandleVerification(BaseMixin):
 
         dpy_message.delete.assert_called_once()
 
-    async def test_verified_only_when_verified(self, dpy_message: discord.Message):
+    async def test_verified_only_when_verified(self, dpy_message: discord.Message) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         assert isinstance(dpy_message.author, discord.User)
@@ -222,7 +234,7 @@ class TestSpellBotHandleVerification(BaseMixin):
 
         dpy_message.delete.assert_not_called()
 
-    async def test_unverified_only_when_unverified(self, dpy_message: discord.Message):
+    async def test_unverified_only_when_unverified(self, dpy_message: discord.Message) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         self.factories.guild.create(xid=dpy_message.guild.id)
@@ -236,7 +248,7 @@ class TestSpellBotHandleVerification(BaseMixin):
 
         dpy_message.delete.assert_not_called()
 
-    async def test_unverified_only_when_verified(self, dpy_message: discord.Message):
+    async def test_unverified_only_when_verified(self, dpy_message: discord.Message) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         assert isinstance(dpy_message.author, discord.User)
@@ -260,7 +272,7 @@ class TestSpellBotHandleVerification(BaseMixin):
         self,
         dpy_message: discord.Message,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         mod_role = MagicMock()
@@ -281,7 +293,7 @@ class TestSpellBotHandleVerification(BaseMixin):
         self,
         dpy_message: discord.Message,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         admin_role = MagicMock()
@@ -302,7 +314,7 @@ class TestSpellBotHandleVerification(BaseMixin):
         self,
         dpy_message: discord.Message,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         monkeypatch.setattr(dpy_message.author, "id", dpy_message.guild.owner_id)
@@ -317,11 +329,11 @@ class TestSpellBotHandleVerification(BaseMixin):
 
         dpy_message.delete.assert_not_called()
 
-    async def test_message_from_administrator(self, dpy_message: discord.Message):
+    async def test_message_from_administrator(self, dpy_message: discord.Message) -> None:
         assert dpy_message.guild
         assert isinstance(dpy_message.guild, discord.Guild)
         admin_perms = discord.Permissions(
-            discord.Permissions.administrator.flag  # pylint: disable=no-member
+            discord.Permissions.administrator.flag,  # pylint: disable=no-member
         )
         dpy_message.channel.permissions_for = MagicMock(return_value=admin_perms)
         self.factories.guild.create(xid=dpy_message.guild.id)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,8 +5,8 @@ from spellbot.settings import Settings
 
 
 class TestMigrations:
-    @pytest.mark.nosession
-    def test_alembic(self, settings: Settings):
+    @pytest.mark.nosession()
+    def test_alembic(self, settings: Settings) -> None:
         from spellbot.models import create_all, reverse_all
 
         create_all(settings.DATABASE_URL)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,15 +5,16 @@ from spellbot.settings import Settings
 
 
 class TestSettings:
-    @pytest.fixture
+    @pytest.fixture()
     def settings(self) -> Settings:
         return Settings()
 
-    def test_guild_object(self, settings: Settings):
+    def test_guild_object(self, settings: Settings) -> None:
         settings.DEBUG_GUILD = None
         assert not settings.GUILD_OBJECT
 
-    def test_guild_object_debug(self, settings: Settings):
+    def test_guild_object_debug(self, settings: Settings) -> None:
         settings.DEBUG_GUILD = "1234"
         obj = settings.GUILD_OBJECT
-        assert obj and obj.id == 1234
+        assert obj
+        assert obj.id == 1234

--- a/tests/test_spelltable.py
+++ b/tests/test_spelltable.py
@@ -14,9 +14,9 @@ from spellbot.settings import Settings
 from spellbot.spelltable import generate_link
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestSpellTable:
-    async def test_generate_link(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_generate_link(self, monkeypatch: pytest.MonkeyPatch) -> None:
         settings = MagicMock(spec=Settings)
         settings.SPELLTABLE_AUTH_KEY = "auth-key"
         settings.SPELLTABLE_CREATE = "https://create"
@@ -30,7 +30,7 @@ class TestSpellTable:
 
         class MockClient:
             @asynccontextmanager
-            async def post(self, *args: Any, **kwargs: Any):  # pylint: disable=W0613
+            async def post(self, *args: Any, **kwargs: Any):  # noqa
                 yield mock_response
 
         mock_client = MockClient()
@@ -46,7 +46,7 @@ class TestSpellTable:
 
         assert await generate_link() == game_url
 
-    async def test_generate_link_missing_game_url(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_generate_link_missing_game_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         settings = MagicMock(spec=Settings)
         settings.SPELLTABLE_AUTH_KEY = "auth-key"
         settings.SPELLTABLE_CREATE = "https://create"
@@ -57,7 +57,7 @@ class TestSpellTable:
 
         class MockClient:
             @asynccontextmanager
-            async def post(self, *args: Any, **kwargs: Any):  # pylint: disable=W0613
+            async def post(self, *args: Any, **kwargs: Any):  # noqa
                 yield mock_response
 
         mock_client = MockClient()
@@ -73,7 +73,7 @@ class TestSpellTable:
 
         assert await generate_link() is None
 
-    async def test_generate_link_non_json(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_generate_link_non_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
         settings = MagicMock(spec=Settings)
         settings.SPELLTABLE_AUTH_KEY = "auth-key"
         settings.SPELLTABLE_CREATE = "https://create"
@@ -84,7 +84,7 @@ class TestSpellTable:
 
         class MockClient:
             @asynccontextmanager
-            async def post(self, *args: Any, **kwargs: Any):  # pylint: disable=W0613
+            async def post(self, *args: Any, **kwargs: Any):  # noqa
                 yield mock_response
 
         mock_client = MockClient()
@@ -100,7 +100,7 @@ class TestSpellTable:
 
         assert await generate_link() is None
 
-    async def test_generate_link_raises_error(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_generate_link_raises_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         settings = MagicMock(spec=Settings)
         settings.SPELLTABLE_AUTH_KEY = "auth-key"
         settings.SPELLTABLE_CREATE = "https://create"
@@ -108,11 +108,11 @@ class TestSpellTable:
 
         class MockClient:  # pragma: no cover
             @asynccontextmanager
-            async def post(self, *args: Any, **kwargs: Any):  # pylint: disable=W0613
+            async def post(self, *args: Any, **kwargs: Any):  # noqa
                 raise ClientError()
 
                 # Need to yield to satisfy static analysis of @asynccontextmanager.
-                yield  # noqa
+                yield
 
         mock_client = MockClient()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,25 +18,25 @@ from spellbot.utils import (
 
 
 class TestUtilsLogging:
-    def test_log_warning(self, caplog: pytest.LogCaptureFixture):
+    def test_log_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         log_warning("log-line %(foo)s", foo="foo")
         assert "log-line foo" in caplog.text
         assert "warning:" in caplog.text
 
 
 class TestUtilsBotCanRole:
-    def test_happy_path(self):
+    def test_happy_path(self) -> None:
         guild = MagicMock()
         guild.me = MagicMock()
         guild.me.guild_permissions = MagicMock()
         assert bot_can_role(guild)
 
-    def test_when_no_me(self):
+    def test_when_no_me(self) -> None:
         guild = MagicMock()
         guild.me = None
         assert not bot_can_role(guild)
 
-    def test_when_no_permissions(self):
+    def test_when_no_permissions(self) -> None:
         guild = MagicMock()
         guild.me = MagicMock()
         guild.me.guild_permissions = MagicMock()
@@ -45,9 +45,9 @@ class TestUtilsBotCanRole:
 
 
 class TestUtilsBotCanReplyTo:
-    def test_happy_path(self):
+    def test_happy_path(self) -> None:
         send_permisions = discord.Permissions(
-            discord.Permissions.send_messages.flag  # pylint: disable=no-member
+            discord.Permissions.send_messages.flag,  # pylint: disable=no-member
         )
         guild = MagicMock(spec=discord.Guild)
         guild.me = MagicMock()
@@ -59,9 +59,9 @@ class TestUtilsBotCanReplyTo:
         message.channel = channel
         assert bot_can_reply_to(message)
 
-    def test_missing_guild(self):
+    def test_missing_guild(self) -> None:
         send_permisions = discord.Permissions(
-            discord.Permissions.send_messages.flag  # pylint: disable=no-member
+            discord.Permissions.send_messages.flag,  # pylint: disable=no-member
         )
         channel = MagicMock(spec=discord.TextChannel)
         channel.type = discord.ChannelType.text
@@ -71,7 +71,7 @@ class TestUtilsBotCanReplyTo:
         message.channel = channel
         assert not bot_can_reply_to(message)
 
-    def test_bad_permissions(self):
+    def test_bad_permissions(self) -> None:
         bad_permisions = discord.Permissions()
         guild = MagicMock(spec=discord.Guild)
         guild.me = MagicMock()
@@ -85,7 +85,7 @@ class TestUtilsBotCanReplyTo:
 
 
 class TestUtilsBotCanRead:
-    def test_happy_path(self):
+    def test_happy_path(self) -> None:
         read_permisions = discord.Permissions(
             discord.Permissions.read_messages.flag  # pylint: disable=no-member
             | discord.Permissions.read_message_history.flag,  # pylint: disable=no-member
@@ -98,7 +98,7 @@ class TestUtilsBotCanRead:
         channel.permissions_for = MagicMock(return_value=read_permisions)
         assert bot_can_read(channel)
 
-    def test_missing_channel_type(self):
+    def test_missing_channel_type(self) -> None:
         read_permisions = discord.Permissions(
             discord.Permissions.read_messages.flag  # pylint: disable=no-member
             | discord.Permissions.read_message_history.flag,  # pylint: disable=no-member
@@ -111,18 +111,18 @@ class TestUtilsBotCanRead:
         channel.permissions_for = MagicMock(return_value=read_permisions)
         assert not bot_can_read(channel)
 
-    def test_private_channel_type(self):
+    def test_private_channel_type(self) -> None:
         channel = MagicMock(spec=discord.TextChannel)
         channel.type = discord.ChannelType.private
         assert bot_can_read(channel)
 
-    def test_missing_guild(self):
+    def test_missing_guild(self) -> None:
         channel = MagicMock(spec=discord.TextChannel)
         channel.type = discord.ChannelType.text
         del channel.guild
         assert bot_can_read(channel)
 
-    def test_bad_permissions(self):
+    def test_bad_permissions(self) -> None:
         bad_permisions = discord.Permissions()
         guild = MagicMock(spec=discord.Guild)
         guild.me = MagicMock()
@@ -134,9 +134,9 @@ class TestUtilsBotCanRead:
 
 
 class TestUtilsBotCanDeleteChannel:
-    def test_happy_path(self):
+    def test_happy_path(self) -> None:
         del_permisions = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         guild = MagicMock(spec=discord.Guild)
         guild.me = MagicMock()
@@ -146,9 +146,9 @@ class TestUtilsBotCanDeleteChannel:
         channel.permissions_for = MagicMock(return_value=del_permisions)
         assert bot_can_delete_channel(channel)
 
-    def test_missing_channel_type(self):
+    def test_missing_channel_type(self) -> None:
         del_permisions = discord.Permissions(
-            discord.Permissions.manage_channels.flag  # pylint: disable=no-member
+            discord.Permissions.manage_channels.flag,  # pylint: disable=no-member
         )
         guild = MagicMock(spec=discord.Guild)
         guild.me = MagicMock()
@@ -158,18 +158,18 @@ class TestUtilsBotCanDeleteChannel:
         channel.permissions_for = MagicMock(return_value=del_permisions)
         assert not bot_can_delete_channel(channel)
 
-    def test_private_channel_type(self):
+    def test_private_channel_type(self) -> None:
         channel = MagicMock(spec=discord.TextChannel)
         channel.type = discord.ChannelType.private
         assert not bot_can_delete_channel(channel)
 
-    def test_missing_guild(self):
+    def test_missing_guild(self) -> None:
         channel = MagicMock(spec=discord.TextChannel)
         channel.type = discord.ChannelType.text
         del channel.guild
         assert not bot_can_delete_channel(channel)
 
-    def test_bad_permissions(self):
+    def test_bad_permissions(self) -> None:
         bad_permisions = discord.Permissions()
         guild = MagicMock(spec=discord.Guild)
         guild.me = MagicMock()
@@ -181,13 +181,13 @@ class TestUtilsBotCanDeleteChannel:
 
 
 class TestUtilsIsAdmin:
-    def test_happy_path(self, settings: Settings):
+    def test_happy_path(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = settings.ADMIN_ROLE
         guild = MagicMock(spec=discord.Guild)
         guild.owner_id = 2
         admin_perms = discord.Permissions(
-            discord.Permissions.administrator.flag  # pylint: disable=no-member
+            discord.Permissions.administrator.flag,  # pylint: disable=no-member
         )
         channel = MagicMock(spec=discord.TextChannel)
         channel.permissions_for = MagicMock(return_value=admin_perms)
@@ -200,19 +200,19 @@ class TestUtilsIsAdmin:
         ctx.author = author
         assert is_admin(ctx)
 
-    def test_missing_guild(self):
+    def test_missing_guild(self) -> None:
         ctx = MagicMock(spec=discord.Interaction)
         del ctx.guild
         with pytest.raises(AdminOnlyError):
             is_admin(ctx)
 
-    def test_missing_channel(self):
+    def test_missing_channel(self) -> None:
         ctx = MagicMock(spec=discord.Interaction)
         del ctx.channel
         with pytest.raises(AdminOnlyError):
             is_admin(ctx)
 
-    def test_when_author_is_owner(self):
+    def test_when_author_is_owner(self) -> None:
         guild = MagicMock(spec=discord.Guild)
         guild.owner_id = 1
         channel = MagicMock(spec=discord.TextChannel)
@@ -224,7 +224,7 @@ class TestUtilsIsAdmin:
         ctx.author = author
         assert is_admin(ctx)
 
-    def test_when_author_has_admin_role(self, settings: Settings):
+    def test_when_author_has_admin_role(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = settings.ADMIN_ROLE
         guild = MagicMock(spec=discord.Guild)
@@ -240,7 +240,7 @@ class TestUtilsIsAdmin:
         ctx.user = author
         assert is_admin(ctx)
 
-    def test_when_author_does_not_have_admin_role(self, settings: Settings):
+    def test_when_author_does_not_have_admin_role(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = f"not-{settings.ADMIN_ROLE}"
         guild = MagicMock(spec=discord.Guild)
@@ -257,7 +257,7 @@ class TestUtilsIsAdmin:
         with pytest.raises(AdminOnlyError):
             is_admin(ctx)
 
-    def test_author_has_no_roles(self, settings: Settings):
+    def test_author_has_no_roles(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = settings.ADMIN_ROLE
         guild = MagicMock(spec=discord.Guild)
@@ -276,7 +276,7 @@ class TestUtilsIsAdmin:
 
 
 class TestUtilsUserCanModerate:
-    def test_owner_happy_path(self, settings: Settings):
+    def test_owner_happy_path(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = f"{settings.MOD_PREFIX}-whatever"
         guild = MagicMock(spec=discord.Guild)
@@ -288,13 +288,13 @@ class TestUtilsUserCanModerate:
         author.id = 1
         assert user_can_moderate(author, guild, channel)
 
-    def test_admin_happy_path(self, settings: Settings):
+    def test_admin_happy_path(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = f"{settings.MOD_PREFIX}-whatever"
         guild = MagicMock(spec=discord.Guild)
         guild.owner_id = 2
         admin_perms = discord.Permissions(
-            discord.Permissions.administrator.flag  # pylint: disable=no-member
+            discord.Permissions.administrator.flag,  # pylint: disable=no-member
         )
         channel = MagicMock(spec=discord.TextChannel)
         channel.permissions_for = MagicMock(return_value=admin_perms)
@@ -302,7 +302,7 @@ class TestUtilsUserCanModerate:
         author.id = 1
         assert user_can_moderate(author, guild, channel)
 
-    def test_non_admin_happy_path(self, settings: Settings):
+    def test_non_admin_happy_path(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = f"{settings.MOD_PREFIX}-whatever"
         guild = MagicMock(spec=discord.Guild)
@@ -314,7 +314,7 @@ class TestUtilsUserCanModerate:
         author.roles = [role]
         assert user_can_moderate(author, guild, channel)
 
-    def test_missing_channel(self, settings: Settings):
+    def test_missing_channel(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = f"{settings.MOD_PREFIX}-whatever"
         guild = MagicMock(spec=discord.Guild)
@@ -324,7 +324,7 @@ class TestUtilsUserCanModerate:
         author.roles = [role]
         assert not user_can_moderate(author, guild, None)
 
-    def test_missing_guild(self, settings: Settings):
+    def test_missing_guild(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = f"{settings.MOD_PREFIX}-whatever"
         channel = MagicMock(spec=discord.TextChannel)
@@ -334,7 +334,7 @@ class TestUtilsUserCanModerate:
         author.roles = [role]
         assert not user_can_moderate(author, None, channel)
 
-    def test_missing_author_roles(self):
+    def test_missing_author_roles(self) -> None:
         guild = MagicMock(spec=discord.Guild)
         guild.owner_id = 2
         channel = MagicMock(spec=discord.TextChannel)
@@ -344,7 +344,7 @@ class TestUtilsUserCanModerate:
         del author.roles
         assert not user_can_moderate(author, guild, channel)
 
-    def test_when_author_does_not_have_mod_role(self, settings: Settings):
+    def test_when_author_does_not_have_mod_role(self, settings: Settings) -> None:
         role = MagicMock()
         role.name = settings.MOD_PREFIX[:2]
         guild = MagicMock(spec=discord.Guild)

--- a/tests/web/test_filters.py
+++ b/tests/web/test_filters.py
@@ -4,12 +4,12 @@ import pytest
 from spellbot.web import humanize
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestWebFilters:
-    async def test_humanize_happy_path(self):
+    async def test_humanize_happy_path(self) -> None:
         s = humanize(1638137981, 480, "America/Los_Angeles")
         assert s == "January 19, 1970, 3:02:17\u202fPM PST"
 
-    async def test_humanize_bogus_timezone(self):
+    async def test_humanize_bogus_timezone(self) -> None:
         s = humanize(1638137981, 480, "BOGUS")
         assert s == "January 19, 1970, 3:02:17\u202fPM UTC"

--- a/tests/web/test_ping.py
+++ b/tests/web/test_ping.py
@@ -4,9 +4,9 @@ import pytest
 from aiohttp.client import ClientSession
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestWebPing:
-    async def test_ping(self, client: ClientSession):
+    async def test_ping(self, client: ClientSession) -> None:
         resp = await client.get("/")
         assert resp.status == 200
         text = await resp.text()

--- a/tests/web/test_record.py
+++ b/tests/web/test_record.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 import pytest
+import pytz
 from aiohttp.client import ClientSession
 from freezegun.api import FrozenDateTimeFactory
 from spellbot.models import GameFormat, GameStatus
@@ -11,7 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 from tests.fixtures import Factories
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestWebRecord:
     async def test_user_record(
         self,
@@ -19,8 +20,8 @@ class TestWebRecord:
         snapshot: SnapshotAssertion,
         factories: Factories,
         freezer: FrozenDateTimeFactory,
-    ):
-        freezer.move_to(datetime(2020, 1, 1))
+    ) -> None:
+        freezer.move_to(datetime(2020, 1, 1, tzinfo=pytz.utc))
         user1 = factories.user.create(xid=101, name="user:1")
         user2 = factories.user.create(xid=102, name="user@2")
         guild = factories.guild.create(xid=201, name="guild")
@@ -32,8 +33,8 @@ class TestWebRecord:
             format=GameFormat.MODERN.value,
             guild=guild,
             channel=channel,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
             message_xid=901,
         )
         game2 = factories.game.create(
@@ -43,8 +44,8 @@ class TestWebRecord:
             format=GameFormat.STANDARD.value,
             guild=guild,
             channel=channel,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
             message_xid=902,
         )
         game3 = factories.game.create(
@@ -54,8 +55,8 @@ class TestWebRecord:
             format=GameFormat.LEGACY.value,
             guild=guild,
             channel=channel,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
             message_xid=903,
         )
         factories.play.create(game_id=game1.id, user_xid=user1.xid, points=3)
@@ -76,8 +77,8 @@ class TestWebRecord:
         snapshot: SnapshotAssertion,
         factories: Factories,
         freezer: FrozenDateTimeFactory,
-    ):
-        freezer.move_to(datetime(2020, 1, 1))
+    ) -> None:
+        freezer.move_to(datetime(2020, 1, 1, tzinfo=pytz.utc))
         user1 = factories.user.create(xid=101, name="user:1")
         user2 = factories.user.create(xid=102, name="user@2")
         guild = factories.guild.create(xid=201, name="guild")
@@ -89,8 +90,8 @@ class TestWebRecord:
             format=GameFormat.MODERN.value,
             guild=guild,
             channel=channel,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
             message_xid=901,
         )
         game2 = factories.game.create(
@@ -100,8 +101,8 @@ class TestWebRecord:
             format=GameFormat.STANDARD.value,
             guild=guild,
             channel=channel,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
             message_xid=902,
         )
         game3 = factories.game.create(
@@ -111,8 +112,8 @@ class TestWebRecord:
             format=GameFormat.LEGACY.value,
             guild=guild,
             channel=channel,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
             message_xid=903,
         )
         factories.play.create(game_id=game1.id, user_xid=user1.xid, points=3)
@@ -138,7 +139,7 @@ class TestWebRecord:
         client: ClientSession,
         snapshot: SnapshotAssertion,
         factories: Factories,
-    ):
+    ) -> None:
         user = factories.user.create(xid=101, name="user")
         guild = factories.guild.create(xid=201, name="guild")
 
@@ -153,8 +154,8 @@ class TestWebRecord:
         snapshot: SnapshotAssertion,
         factories: Factories,
         freezer: FrozenDateTimeFactory,
-    ):
-        freezer.move_to(datetime(2020, 1, 1))
+    ) -> None:
+        freezer.move_to(datetime(2020, 1, 1, tzinfo=pytz.utc))
         user1 = factories.user.create(xid=101, name="user1")
         user2 = factories.user.create(xid=102, name="user2")
         guild = factories.guild.create(xid=201, name="guild")
@@ -167,8 +168,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=901,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         game2 = factories.game.create(
             id=2,
@@ -178,8 +179,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=902,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         game3 = factories.game.create(
             id=3,
@@ -189,8 +190,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=903,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         factories.play.create(game_id=game1.id, user_xid=user1.xid, points=3)
         factories.play.create(game_id=game1.id, user_xid=user2.xid, points=1)
@@ -210,8 +211,8 @@ class TestWebRecord:
         snapshot: SnapshotAssertion,
         factories: Factories,
         freezer: FrozenDateTimeFactory,
-    ):
-        freezer.move_to(datetime(2020, 1, 1))
+    ) -> None:
+        freezer.move_to(datetime(2020, 1, 1, tzinfo=pytz.utc))
         user1 = factories.user.create(xid=101, name="user1")
         user2 = factories.user.create(xid=102, name="user2")
         guild = factories.guild.create(xid=201, name="guild")
@@ -224,8 +225,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=901,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         game2 = factories.game.create(
             id=2,
@@ -235,8 +236,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=902,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         game3 = factories.game.create(
             id=3,
@@ -246,8 +247,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=903,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         factories.play.create(game_id=game1.id, user_xid=user1.xid, points=3)
         factories.play.create(game_id=game1.id, user_xid=user2.xid, points=1)
@@ -273,8 +274,8 @@ class TestWebRecord:
         snapshot: SnapshotAssertion,
         factories: Factories,
         freezer: FrozenDateTimeFactory,
-    ):
-        freezer.move_to(datetime(2020, 1, 1))
+    ) -> None:
+        freezer.move_to(datetime(2020, 1, 1, tzinfo=pytz.utc))
         user1 = factories.user.create(xid=101, name="user1")
         user2 = factories.user.create(xid=102, name="user2")
         guild = factories.guild.create(xid=201, name="guild")
@@ -287,8 +288,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=901,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         game2 = factories.game.create(
             id=2,
@@ -298,8 +299,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=902,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         game3 = factories.game.create(
             id=3,
@@ -309,8 +310,8 @@ class TestWebRecord:
             guild=guild,
             channel=channel,
             message_xid=903,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=pytz.utc),
+            updated_at=datetime.now(tz=pytz.utc),
         )
         factories.play.create(game_id=game1.id, user_xid=user1.xid, points=3)
         factories.play.create(game_id=game1.id, user_xid=user2.xid, points=1)
@@ -335,7 +336,7 @@ class TestWebRecord:
         client: ClientSession,
         snapshot: SnapshotAssertion,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(xid=201, name="guild")
         channel = factories.channel.create(xid=101, name="channel", guild=guild)
 
@@ -344,11 +345,11 @@ class TestWebRecord:
         text = await resp.text()
         assert text == snapshot
 
-    async def test_user_record_invalid_ids(self, client: ClientSession):
+    async def test_user_record_invalid_ids(self, client: ClientSession) -> None:
         resp = await client.get("/g/abc/u/xyz")
         assert resp.status == 404
 
-    async def test_channel_record_invalid_ids(self, client: ClientSession):
+    async def test_channel_record_invalid_ids(self, client: ClientSession) -> None:
         resp = await client.get("/g/abc/c/xyz")
         assert resp.status == 404
 
@@ -356,7 +357,7 @@ class TestWebRecord:
         self,
         client: ClientSession,
         factories: Factories,
-    ):
+    ) -> None:
         user = factories.user.create(xid=101, name="user")
         resp = await client.get(f"/g/404/u/{user.xid}")
         assert resp.status == 404
@@ -365,7 +366,7 @@ class TestWebRecord:
         self,
         client: ClientSession,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(xid=201, name="guild")
         channel = factories.channel.create(xid=301, name="channel", guild=guild)
         resp = await client.get(f"/g/404/c/{channel.xid}")
@@ -375,7 +376,7 @@ class TestWebRecord:
         self,
         client: ClientSession,
         factories: Factories,
-    ):
+    ) -> None:
         guild = factories.guild.create(xid=201, name="guild")
         resp = await client.get(f"/g/{guild.xid}/c/404")
         assert resp.status == 404


### PR DESCRIPTION
**Description**

Automatically forget channels if they've been deleted when the `/channels` command runs.

- Resolves #654

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
