### PR TITLE
Adds retry logic to discord operations

### DIFF
--- a/src/spellbot/client.py
+++ b/src/spellbot/client.py
@@ -14,6 +14,7 @@ from expiringdict import ExpiringDict
 
 from .database import db_session_manager, initialize_connection
 from .metrics import setup_ignored_errors, setup_metrics
+from .operations import safe_delete_message
 from .services import ChannelsService, GamesService, GuildsService, VerifiesService
 from .settings import Settings
 from .spelltable import generate_link
@@ -152,9 +153,9 @@ class SpellBot(AutoShardedBot):
         if not user_can_moderate(message.author, guild, message.channel):
             user_is_verified = await verify.is_verified()
             if user_is_verified and channel_data["unverified_only"]:
-                await message.delete()
+                await safe_delete_message(message)
             if not user_is_verified and channel_data["verified_only"]:
-                await message.delete()
+                await safe_delete_message(message)
 
     @tracer.wrap()
     async def handle_message_deleted(self, message: discord.Message) -> None:

--- a/src/spellbot/cogs/events_cog.py
+++ b/src/spellbot/cogs/events_cog.py
@@ -11,6 +11,7 @@ from .. import SpellBot
 from ..actions import LookingForGameAction
 from ..metrics import add_span_context
 from ..models import GameFormat
+from ..operations import safe_defer_interaction
 from ..utils import for_all_callbacks, is_admin, is_guild
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ class EventsCog(commands.Cog):
     ) -> None:
         assert interaction.channel_id is not None
         add_span_context(interaction)
-        await interaction.response.defer()
+        await safe_defer_interaction(interaction)
         async with LookingForGameAction.create(self.bot, interaction) as action:
             await action.create_game(players, format)
 

--- a/src/spellbot/cogs/lfg_cog.py
+++ b/src/spellbot/cogs/lfg_cog.py
@@ -11,6 +11,7 @@ from .. import SpellBot
 from ..actions.lfg_action import LookingForGameAction
 from ..metrics import add_span_context
 from ..models import GameFormat
+from ..operations import safe_defer_interaction
 from ..utils import for_all_callbacks, is_guild
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ class LookingForGameCog(commands.Cog):
     ) -> None:
         assert interaction.channel_id is not None
         add_span_context(interaction)
-        await interaction.response.defer()
+        await safe_defer_interaction(interaction)
         async with self.bot.channel_lock(interaction.channel_id):
             async with LookingForGameAction.create(self.bot, interaction) as action:
                 await action.execute(friends=friends, seats=seats, format=format)

--- a/src/spellbot/views/setup_view.py
+++ b/src/spellbot/views/setup_view.py
@@ -6,6 +6,7 @@ import discord
 from ddtrace import tracer
 
 from ..metrics import add_span_context
+from ..operations import safe_defer_interaction
 from ..utils import is_admin
 from ..views import BaseView
 
@@ -33,7 +34,7 @@ class SetupView(BaseView):
         from ..actions.admin_action import AdminAction
 
         with tracer.trace(name="interaction", resource="toggle_show_links"):
-            await interaction.response.defer()
+            await safe_defer_interaction(interaction)
             add_span_context(interaction)
             async with AdminAction.create(self.bot, interaction) as action:
                 await action.toggle_show_links()
@@ -52,7 +53,7 @@ class SetupView(BaseView):
         from ..actions.admin_action import AdminAction
 
         with tracer.trace(name="interaction", resource="toggle_voice_create"):
-            await interaction.response.defer()
+            await safe_defer_interaction(interaction)
             add_span_context(interaction)
             async with AdminAction.create(self.bot, interaction) as action:
                 await action.toggle_voice_create()
@@ -71,7 +72,7 @@ class SetupView(BaseView):
         from ..actions.admin_action import AdminAction
 
         with tracer.trace(name="interaction", resource="refresh_setup"):
-            await interaction.response.defer()
+            await safe_defer_interaction(interaction)
             add_span_context(interaction)
             async with AdminAction.create(self.bot, interaction) as action:
                 await action.refresh_setup()


### PR DESCRIPTION
**Description**

- Adds retry logic to all discord operations
- Adds `safe_defer_interaction()` rather than calling `interaction.response.defer()` directly, so that we can have retry logic for this discord operation
- Converts some `message.delete()` calls into `safe_delete_message()` calls

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
