### PR TITLE
add Pauper EDH to enums

### DIFF
--- a/src/spellbot/enums.py
+++ b/src/spellbot/enums.py
@@ -88,7 +88,7 @@ class GameFormat(Enum):
     OATHBREAKER = 4
     DUEL_COMMANDER = 2
     CEDH = 4, "cEDH"
-    ARCHENEMY = 4,
+    ARCHENEMY = 4
     PAUPER_EDH = 4, "Pauper EDH"
 
 
@@ -104,6 +104,7 @@ GAME_FORMAT_ORDER = [
     GameFormat.TWO_HEADED_GIANT,
     GameFormat.BRAWL_MULTIPLAYER,
     GameFormat.CEDH,
+    GameFormat.PAUPER_EDH,
     GameFormat.OATHBREAKER,
     GameFormat.ARCHENEMY,
     GameFormat.DUEL_COMMANDER,
@@ -115,5 +116,4 @@ GAME_FORMAT_ORDER = [
     GameFormat.VINTAGE,
     GameFormat.SEALED,
     GameFormat.BRAWL_TWO_PLAYER,
-    GameFormat.PAUPER_EDH,
 ]

--- a/src/spellbot/enums.py
+++ b/src/spellbot/enums.py
@@ -88,7 +88,8 @@ class GameFormat(Enum):
     OATHBREAKER = 4
     DUEL_COMMANDER = 2
     CEDH = 4, "cEDH"
-    ARCHENEMY = 4
+    ARCHENEMY = 4,
+    PAUPER_EDH = 4, "Pauper EDH"
 
 
 GAME_FORMAT_ORDER = [
@@ -114,4 +115,5 @@ GAME_FORMAT_ORDER = [
     GameFormat.VINTAGE,
     GameFormat.SEALED,
     GameFormat.BRAWL_TWO_PLAYER,
+    GameFormat.PAUPER_EDH,
 ]


### PR DESCRIPTION
Pauper EDH and Pauper Commander are the same thing.
4 Player, 30 Life format
https://pdhhomebase.com/rules/

I couldn't see health in your repo, so I think that's handled by SpellTable...
Maintainers feel free to edit where I've made mistakes.

**Description**
I've been playing competitive pauper commander, and the community have been using your bot to create games.
Since we've got to modify the health to 30 this saves us a little bit of hassle.

- Resolves #1753 

**Checklist**

- [ ] Add tests for these changes
- [X] Test coverage is not decreased
- [X] Entire test suite passes
