### PR TITLE
Implement Playgroup Live support

### DIFF
--- a/src/spellbot/actions/lfg_action.py
+++ b/src/spellbot/actions/lfg_action.py
@@ -12,6 +12,7 @@ from ddtrace.trace import tracer
 
 from spellbot import services
 from spellbot.enums import GameBracket, GameFormat, GameService
+from spellbot.integrations import playgroup_live
 from spellbot.models import MAX_RULES_LENGTH, GameStatus, generate_pin
 from spellbot.operations import (
     VoiceChannelSuggestion,
@@ -44,6 +45,18 @@ logger = logging.getLogger(__name__)
 class LookingForGameAction(BaseAction):
     def __init__(self, bot: SpellBot, interaction: discord.Interaction) -> None:
         super().__init__(bot, interaction)
+
+    async def block_if_no_player_linked(self, game_data: GameData) -> bool:
+        if game_data.service != GameService.PLAYGROUP_LIVE.value:
+            return False
+        if playgroup_live.find_linked_player(game_data) is not None:
+            return False
+        await safe_followup_channel(
+            self.interaction,
+            "To use Playgroup Live, at least one player must link their account. "
+            "Run `/playgroup link` and try again.",
+        )
+        return True
 
     @tracer.wrap()
     async def get_friends(self, friends: str | None = None) -> str:
@@ -220,9 +233,19 @@ class LookingForGameAction(BaseAction):
             )
             return
 
+        if await self.block_if_no_player_linked(game_data):
+            return
+
+        original_seats = (
+            game_data.seats if game_data.service == GameService.PLAYGROUP_LIVE.value else None
+        )
         game_data = await services.games.shrink_game(game_data)
         player_xids = [player.xid for player in game_data.players]
-        game_data, suggested_vc = await self.make_game_ready(game_data, player_xids=player_xids)
+        game_data, suggested_vc = await self.make_game_ready(
+            game_data,
+            player_xids=player_xids,
+            original_seats=original_seats,
+        )
         assert self.interaction.guild_id
         game_data = await self.handle_voice_creation(game_data, self.interaction.guild_id)
         game_data = await self.handle_embed_creation(
@@ -237,7 +260,7 @@ class LookingForGameAction(BaseAction):
         await self.handle_direct_messages(game_data, suggested_vc=suggested_vc, rematch=False)
 
     @tracer.wrap()
-    async def execute(
+    async def execute(  # noqa: C901
         self,
         friends: str | None = None,
         seats: int | None = None,
@@ -305,6 +328,8 @@ class LookingForGameAction(BaseAction):
         other_game_ids: list[int] = []
         suggested_vc = None
         if game_data.fully_seated:
+            if await self.block_if_no_player_linked(game_data):
+                return None
             other_game_ids = await services.games.other_game_ids(game_data)
             player_xids = [player.xid for player in game_data.players]
             game_data, suggested_vc = await self.make_game_ready(game_data, player_xids)
@@ -423,6 +448,7 @@ class LookingForGameAction(BaseAction):
         self,
         game_data: GameData,
         player_xids: list[int],
+        original_seats: int | None = None,
     ) -> tuple[GameData, VoiceChannelSuggestion | None]:
         # Convoke needs player pins, so we have to generate them before creating the game link.
         # Initially the design was to let the DB do this later, in the `make_ready()` method.
@@ -431,7 +457,7 @@ class LookingForGameAction(BaseAction):
         # method of the Game object will return None for players if MT is not enabled.
         pins = [generate_pin() for _ in player_xids]
 
-        details = await self.bot.create_game_link(game_data, pins)
+        details = await self.bot.create_game_link(game_data, pins, original_seats=original_seats)
 
         suggested_vc = None
         if (

--- a/src/spellbot/client.py
+++ b/src/spellbot/client.py
@@ -18,7 +18,7 @@ from . import services
 from .data import GameLinkDetails
 from .database import db_session_manager, initialize_connection
 from .enums import GameService
-from .integrations import convoke, edhlab, girudo, tablestream
+from .integrations import convoke, edhlab, girudo, playgroup_live, tablestream
 from .metrics import add_span_request_id, generate_request_id, setup_metrics
 from .operations import safe_delete_message
 from .settings import settings
@@ -163,6 +163,7 @@ class SpellBot(AutoShardedBot):
         self,
         game_data: GameData,
         pins: list[str] | None = None,
+        original_seats: int | None = None,
     ) -> GameLinkDetails:
         if self.mock_games:
             return GameLinkDetails(f"http://example.com/game/{uuid4()}")
@@ -181,6 +182,9 @@ class SpellBot(AutoShardedBot):
                 return GameLinkDetails(details.link, details.password)
             case GameService.EDHLAB.value:
                 details = await edhlab.generate_link(game_data)
+                return GameLinkDetails(*details)
+            case GameService.PLAYGROUP_LIVE.value:
+                details = await playgroup_live.generate_link(game_data, original_seats)
                 return GameLinkDetails(*details)
             case _:
                 return GameLinkDetails()

--- a/src/spellbot/cogs/__init__.py
+++ b/src/spellbot/cogs/__init__.py
@@ -16,6 +16,7 @@ from .events_cog import EventsCog
 from .leave_cog import LeaveGameCog
 from .lfg_cog import LookingForGameCog
 from .owner_cog import OwnerCog
+from .playgroup_cog import PlaygroupCog
 from .score_cog import ScoreCog
 from .tasks_cog import TasksCog
 from .verify_cog import VerifyCog
@@ -36,6 +37,7 @@ __all__ = [
     "LeaveGameCog",
     "LookingForGameCog",
     "OwnerCog",
+    "PlaygroupCog",
     "ScoreCog",
     "TasksCog",
     "VerifyCog",

--- a/src/spellbot/cogs/admin_cog.py
+++ b/src/spellbot/cogs/admin_cog.py
@@ -10,7 +10,7 @@ from discord.app_commands import Choice
 from discord.ext import commands
 
 from spellbot.actions import AdminAction
-from spellbot.enums import GAME_BRACKET_ORDER, GAME_FORMAT_ORDER, GAME_SERVICE_ORDER
+from spellbot.enums import GAME_BRACKET_ORDER, GAME_FORMAT_ORDER, visible_game_services
 from spellbot.metrics import add_span_context
 from spellbot.settings import settings
 from spellbot.utils import for_all_callbacks, is_admin, is_guild, is_mod
@@ -243,7 +243,7 @@ class AdminCog(commands.Cog):
     )
     @app_commands.describe(service="Default service")
     @app_commands.choices(
-        service=[Choice(name=str(service), value=service.value) for service in GAME_SERVICE_ORDER],
+        service=[Choice(name=str(service), value=service.value) for service in visible_game_services()],
     )
     @tracer.wrap(name="interaction", resource="set_default_service")
     async def default_service(self, interaction: discord.Interaction, service: int) -> None:

--- a/src/spellbot/cogs/events_cog.py
+++ b/src/spellbot/cogs/events_cog.py
@@ -10,7 +10,7 @@ from discord.app_commands import Choice
 from discord.ext import commands
 
 from spellbot.actions import LookingForGameAction
-from spellbot.enums import GAME_BRACKET_ORDER, GAME_FORMAT_ORDER, GAME_SERVICE_ORDER
+from spellbot.enums import GAME_BRACKET_ORDER, GAME_FORMAT_ORDER, visible_game_services
 from spellbot.metrics import add_span_context
 from spellbot.operations import safe_defer_interaction
 from spellbot.settings import settings
@@ -40,7 +40,7 @@ class EventsCog(commands.Cog):
     )
     @app_commands.describe(service="What service do you want to use to play this game?")
     @app_commands.choices(
-        service=[Choice(name=str(service), value=service.value) for service in GAME_SERVICE_ORDER],
+        service=[Choice(name=str(service), value=service.value) for service in visible_game_services()],
     )
     @tracer.wrap(name="interaction", resource="game")
     async def game(

--- a/src/spellbot/cogs/lfg_cog.py
+++ b/src/spellbot/cogs/lfg_cog.py
@@ -10,7 +10,7 @@ from discord.app_commands import Choice
 from discord.ext import commands
 
 from spellbot.actions.lfg_action import LookingForGameAction
-from spellbot.enums import GAME_BRACKET_ORDER, GAME_FORMAT_ORDER, GAME_SERVICE_ORDER
+from spellbot.enums import GAME_BRACKET_ORDER, GAME_FORMAT_ORDER, visible_game_services
 from spellbot.metrics import add_span_context
 from spellbot.operations import safe_defer_interaction
 from spellbot.settings import settings
@@ -46,7 +46,7 @@ class LookingForGameCog(commands.Cog):
     @app_commands.describe(rules="Any additional rules or requests for this game.")
     @app_commands.describe(service="What service do you want to use to play this game?")
     @app_commands.choices(
-        service=[Choice(name=str(service), value=service.value) for service in GAME_SERVICE_ORDER],
+        service=[Choice(name=str(service), value=service.value) for service in visible_game_services()],
     )
     @app_commands.describe(format="What game format do you want to play?")
     @app_commands.choices(

--- a/src/spellbot/cogs/playgroup_cog.py
+++ b/src/spellbot/cogs/playgroup_cog.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+import httpx
+from ddtrace.trace import tracer
+from discord import app_commands
+from discord.ext import commands
+
+from spellbot.database import db_session_manager
+from spellbot.integrations.playgroup_live import TIMEOUT_S, lookup_playgroup_user
+from spellbot.metrics import add_span_context
+from spellbot import services
+from spellbot.settings import settings
+from spellbot.utils import for_all_callbacks, is_guild
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from spellbot import SpellBot
+
+
+@for_all_callbacks(app_commands.check(is_guild))
+class PlaygroupCog(commands.Cog):
+    playgroup = app_commands.Group(name="playgroup", description="Playgroup Live commands")
+
+    def __init__(self, bot: SpellBot) -> None:
+        self.bot = bot
+
+    @playgroup.command(
+        name="link",
+        description="Link your Discord account to your Playgroup Live account.",
+    )
+    @app_commands.checks.cooldown(1, 60)
+    @tracer.wrap(name="interaction", resource="playgroup_link")
+    async def link(self, interaction: discord.Interaction) -> None:
+        add_span_context(interaction)
+        await interaction.response.defer(ephemeral=True)
+
+        async with db_session_manager():
+            user_data = await services.users.get(interaction.user.id)
+
+            if user_data and user_data.playgroup_user_id is not None:
+                await interaction.followup.send(
+                    "Your Discord account is already linked to Playgroup Live!",
+                    ephemeral=True,
+                )
+                return
+
+            timeout = httpx.Timeout(TIMEOUT_S, connect=TIMEOUT_S, read=TIMEOUT_S, write=TIMEOUT_S)
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                playgroup_user_id, username = await lookup_playgroup_user(
+                    client,
+                    interaction.user.id,
+                )
+
+            if playgroup_user_id is not None:
+                await services.users.set_playgroup_user_id(
+                    interaction.user.id,
+                    playgroup_user_id,
+                )
+                await interaction.followup.send(
+                    f"Linked! Welcome, **{username}**. "
+                    "Your Playgroup Live games will now be attributed to your account.",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.followup.send(
+                    "No Playgroup account found for your Discord. "
+                    "Go to <https://playgroup.gg/profiles> and click **Link Discord**, "
+                    "then run `/playgroup link` again to confirm.",
+                    ephemeral=True,
+                )
+
+
+async def setup(bot: SpellBot) -> None:  # pragma: no cover
+    await bot.add_cog(PlaygroupCog(bot), guild=settings.GUILD_OBJECT)

--- a/src/spellbot/data/user_data.py
+++ b/src/spellbot/data/user_data.py
@@ -20,3 +20,4 @@ class UserData:
     updated_at: datetime
     name: str
     banned: bool
+    playgroup_user_id: int | None = None

--- a/src/spellbot/enums.py
+++ b/src/spellbot/enums.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, NamedTuple
 
+from spellbot.settings import settings
+
 
 # Additional metadata related to supported game formats.
 class FormatDetails(NamedTuple):
@@ -93,10 +95,20 @@ class GameService(Enum):
         "https://edhlab.gg/",
         4,
     )
+    PLAYGROUP_LIVE = (
+        "Playgroup Live",
+        (
+            "_A {emoji}[Playgroup Live](https://playgroup.gg/) link will "
+            "be created when all players have joined._"
+        ),
+        "https://playgroup.gg/",
+        6,
+    )
 
 
 GAME_SERVICE_ORDER = [
     GameService.CONVOKE,
+    GameService.PLAYGROUP_LIVE,
     GameService.TABLE_STREAM,
     GameService.GIRUDO,
     GameService.EDHLAB,
@@ -108,6 +120,12 @@ GAME_SERVICE_ORDER = [
     GameService.TTS,
     GameService.NOT_ANY,
 ]
+
+
+def visible_game_services() -> list[GameService]:
+    if settings.PLAYGROUP_LIVE_API_KEY:
+        return GAME_SERVICE_ORDER
+    return [s for s in GAME_SERVICE_ORDER if s is not GameService.PLAYGROUP_LIVE]
 
 
 class GameFormat(Enum):

--- a/src/spellbot/integrations/playgroup_live.py
+++ b/src/spellbot/integrations/playgroup_live.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from spellbot import __version__
+from spellbot.enums import GameBracket, GameFormat, GameService
+from spellbot.metrics import add_span_error
+from spellbot.settings import settings
+
+if TYPE_CHECKING:
+    from spellbot.data import GameData
+
+logger = logging.getLogger(__name__)
+
+RETRY_ATTEMPTS = 2
+RETRY_BACKOFF_S = 0.2
+TIMEOUT_S = 3
+MAX_PLAYERS = GameService.PLAYGROUP_LIVE.max_seats
+
+
+def _api_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {settings.PLAYGROUP_LIVE_API_KEY}",
+        "User-Agent": f"spellbot/{__version__}",
+    }
+
+
+def playgroup_life_amount(format: GameFormat) -> int:
+    match format:
+        case (
+            GameFormat.COMMANDER
+            | GameFormat.EDH_MAX
+            | GameFormat.EDH_HIGH
+            | GameFormat.EDH_MID
+            | GameFormat.EDH_LOW
+            | GameFormat.EDH_BATTLECRUISER
+            | GameFormat.PRE_CONS
+            | GameFormat.CEDH
+            | GameFormat.PAUPER_EDH
+            | GameFormat.PLANECHASE
+            | GameFormat.ARCHENEMY
+            | GameFormat.HORDE_MAGIC
+        ):
+            return 40
+        case GameFormat.TWO_HEADED_GIANT:
+            return 30
+        case GameFormat.BRAWL_TWO_PLAYER | GameFormat.BRAWL_MULTIPLAYER:
+            return 25
+        case _:
+            return 20
+
+
+def playgroup_bracket(bracket: int) -> int | None:
+    if bracket == GameBracket.NONE.value:
+        return None
+    mapped = bracket - GameBracket.NONE.value
+    return mapped if 1 <= mapped <= 5 else None
+
+
+def find_linked_player(game_data: GameData) -> int | None:
+    for player in game_data.players:
+        if player.playgroup_user_id is not None:
+            return player.playgroup_user_id
+    return None
+
+
+async def lookup_playgroup_user(
+    client: httpx.AsyncClient,
+    discord_id: int,
+) -> tuple[int | None, str | None]:
+    endpoint = f"{settings.PLAYGROUP_LIVE_API_URL}/api/v2/users/by_discord/{discord_id}"
+    try:
+        resp = await client.get(endpoint, headers=_api_headers())
+        if resp.status_code == 404:
+            logger.info("Playgroup user not found for Discord ID %s", discord_id)
+            return None, None
+        resp.raise_for_status()
+        data = resp.json()
+        user_id = data["id"]
+        username = data["username"]
+    except httpx.HTTPStatusError:
+        logger.warning("Playgroup user lookup API error for Discord %s", discord_id, exc_info=True)
+        return None, None
+    except Exception:
+        logger.warning("Playgroup user lookup failed for Discord %s", discord_id, exc_info=True)
+        return None, None
+    else:
+        logger.info(
+            "Playgroup user lookup: Discord %s -> Playgroup user %s",
+            discord_id,
+            user_id,
+        )
+        return user_id, username
+
+
+async def fetch_playgroup_live_session(
+    client: httpx.AsyncClient,
+    game_data: GameData,
+    playgroup_user_id: int,
+    player_amount: int,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "player_amount": min(player_amount, MAX_PLAYERS),
+        "life_amount": playgroup_life_amount(GameFormat(game_data.format)),
+        "client_identifier": "spellbot",
+        "on_behalf_of_user_id": playgroup_user_id,
+    }
+    bracket_value = playgroup_bracket(game_data.bracket)
+    if bracket_value is not None:
+        payload["bracket"] = bracket_value
+
+    endpoint = f"{settings.PLAYGROUP_LIVE_API_URL}/api/public/v1/live_sessions"
+    resp = await client.post(endpoint, json=payload, headers=_api_headers())
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def generate_link(
+    game_data: GameData,
+    original_seats: int | None = None,
+) -> tuple[str | None, str | None]:
+    if not settings.PLAYGROUP_LIVE_API_KEY:
+        logger.warning("Playgroup Live API key not configured")
+        return None, None
+
+    playgroup_user_id = find_linked_player(game_data)
+    if playgroup_user_id is None:
+        return None, None
+
+    player_amount = original_seats or game_data.seats
+
+    timeout = httpx.Timeout(TIMEOUT_S, connect=TIMEOUT_S, read=TIMEOUT_S, write=TIMEOUT_S)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for attempt in range(RETRY_ATTEMPTS):
+            try:
+                data = await fetch_playgroup_live_session(
+                    client,
+                    game_data,
+                    playgroup_user_id,
+                    player_amount,
+                )
+            except Exception as ex:
+                add_span_error(ex)
+                if attempt == RETRY_ATTEMPTS - 1:
+                    logger.exception("Playgroup Live API failure (final attempt)")
+                    return None, None
+                logger.warning(
+                    "Playgroup Live API issue (attempt %s)",
+                    attempt + 1,
+                    exc_info=True,
+                )
+                await asyncio.sleep(RETRY_BACKOFF_S * (2**attempt))
+                continue
+
+            if not data:
+                return None, None
+            game_link = data["url"]
+            logger.info("Playgroup Live session created for game %s: %s", game_data.id, game_link)
+            return game_link, None
+
+    return None, None

--- a/src/spellbot/migrations/versions/c4d5e6f7a8b9_add_playgroup_user_id_to_users.py
+++ b/src/spellbot/migrations/versions/c4d5e6f7a8b9_add_playgroup_user_id_to_users.py
@@ -1,0 +1,27 @@
+"""
+Add playgroup_user_id to users.
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-05-07 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c4d5e6f7a8b9"
+down_revision = "b3c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("playgroup_user_id", sa.BigInteger(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "playgroup_user_id")

--- a/src/spellbot/models/user.py
+++ b/src/spellbot/models/user.py
@@ -55,6 +55,12 @@ class User(Base):
         server_default=false(),
         doc="If true, this user is banned from using SpellBot",
     )
+    playgroup_user_id = Column(
+        BigInteger,
+        nullable=True,
+        default=None,
+        doc="The Playgroup Live user ID linked to this Discord user",
+    )
 
     queues = relationship(
         "Queue",
@@ -123,4 +129,5 @@ class User(Base):
             updated_at=self.updated_at,  # type: ignore
             name=self.name,  # type: ignore
             banned=self.banned,  # type: ignore
+            playgroup_user_id=self.playgroup_user_id,
         )

--- a/src/spellbot/services/users.py
+++ b/src/spellbot/services/users.py
@@ -118,6 +118,15 @@ async def set_banned(user_xid: int, banned: bool) -> UserData:
 
 
 @tracer.wrap()
+async def set_playgroup_user_id(user_xid: int, playgroup_user_id: int) -> None:
+    """Store the Playgroup Live user ID for the given Discord user."""
+    await DatabaseSession.execute(
+        update(User).where(User.xid == user_xid).values(playgroup_user_id=playgroup_user_id),  # type: ignore
+    )
+    await DatabaseSession.commit()
+
+
+@tracer.wrap()
 async def current_game_id(user_data: UserData, channel_xid: int) -> int | None:
     """Get the current PENDING game id for the user in the given channel."""
     queue = (

--- a/src/spellbot/settings.py
+++ b/src/spellbot/settings.py
@@ -63,6 +63,8 @@ class Settings:
         "PATREON_SYNC_LOOP_M",
         "PATREON_TOKEN",
         "PENDING_EMBED_COLOR",
+        "PLAYGROUP_LIVE_API_KEY",
+        "PLAYGROUP_LIVE_API_URL",
         "PORT",
         "REDIS_URL",
         "SECRET_TOKEN",
@@ -138,6 +140,10 @@ class Settings:
         self.EDHLAB_API_KEY = getenv("EDHLAB_API_KEY")
         self.EDHLAB_ROOT = getenv("EDHLAB_ROOT", "https://wmlcambifdkwygvwnpas.supabase.co")
         self.EDHLAB_CREATE = f"{self.EDHLAB_ROOT}/functions/v1/create-spellbot-game"
+
+        # playgroup live integration
+        self.PLAYGROUP_LIVE_API_URL = getenv("PLAYGROUP_LIVE_API_URL", "https://playgroup.gg")
+        self.PLAYGROUP_LIVE_API_KEY = getenv("PLAYGROUP_LIVE_API_KEY")
 
         # configuration
         self.BOT_INVITE_LINK = (

--- a/tests/integrations/test_playgroup_live.py
+++ b/tests/integrations/test_playgroup_live.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import spellbot.integrations.playgroup_live as playgroup_live_module
+from spellbot.enums import GameBracket, GameFormat, GameService
+from spellbot.integrations.playgroup_live import (
+    fetch_playgroup_live_session,
+    generate_link,
+    find_linked_player,
+    lookup_playgroup_user,
+    playgroup_bracket,
+    playgroup_life_amount,
+)
+from tests.mocks import create_mock_game, create_mock_user
+
+
+class TestPlaygroupLifeAmount:
+    @pytest.mark.parametrize(
+        ("game_format", "expected"),
+        [
+            pytest.param(GameFormat.COMMANDER, 40, id="commander"),
+            pytest.param(GameFormat.EDH_MAX, 40, id="edh_max"),
+            pytest.param(GameFormat.EDH_HIGH, 40, id="edh_high"),
+            pytest.param(GameFormat.EDH_MID, 40, id="edh_mid"),
+            pytest.param(GameFormat.EDH_LOW, 40, id="edh_low"),
+            pytest.param(GameFormat.EDH_BATTLECRUISER, 40, id="edh_battlecruiser"),
+            pytest.param(GameFormat.PRE_CONS, 40, id="pre_cons"),
+            pytest.param(GameFormat.CEDH, 40, id="cedh"),
+            pytest.param(GameFormat.PAUPER_EDH, 40, id="pauper_edh"),
+            pytest.param(GameFormat.PLANECHASE, 40, id="planechase"),
+            pytest.param(GameFormat.ARCHENEMY, 40, id="archenemy"),
+            pytest.param(GameFormat.HORDE_MAGIC, 40, id="horde_magic"),
+            pytest.param(GameFormat.TWO_HEADED_GIANT, 30, id="two_headed_giant"),
+            pytest.param(GameFormat.BRAWL_TWO_PLAYER, 25, id="brawl_two_player"),
+            pytest.param(GameFormat.BRAWL_MULTIPLAYER, 25, id="brawl_multiplayer"),
+            pytest.param(GameFormat.STANDARD, 20, id="standard"),
+            pytest.param(GameFormat.MODERN, 20, id="modern"),
+            pytest.param(GameFormat.PIONEER, 20, id="pioneer"),
+            pytest.param(GameFormat.PAUPER, 20, id="pauper"),
+            pytest.param(GameFormat.LEGACY, 20, id="legacy"),
+            pytest.param(GameFormat.VINTAGE, 20, id="vintage"),
+            pytest.param(GameFormat.SEALED, 20, id="sealed"),
+            pytest.param(GameFormat.OATHBREAKER, 20, id="oathbreaker"),
+            pytest.param(GameFormat.DUEL_COMMANDER, 20, id="duel_commander"),
+        ],
+    )
+    def test_life_amount_mapping(self, game_format: GameFormat, expected: int) -> None:
+        assert playgroup_life_amount(game_format) == expected
+
+    def test_all_formats_covered(self) -> None:
+        for fmt in GameFormat:
+            result = playgroup_life_amount(fmt)
+            assert isinstance(result, int)
+            assert result > 0
+
+
+class TestPlaygroupBracket:
+    @pytest.mark.parametrize(
+        ("bracket", "expected"),
+        [
+            pytest.param(GameBracket.NONE.value, None, id="none"),
+            pytest.param(GameBracket.BRACKET_1.value, 1, id="bracket_1"),
+            pytest.param(GameBracket.BRACKET_2.value, 2, id="bracket_2"),
+            pytest.param(GameBracket.BRACKET_3.value, 3, id="bracket_3"),
+            pytest.param(GameBracket.BRACKET_4.value, 4, id="bracket_4"),
+            pytest.param(GameBracket.BRACKET_5.value, 5, id="bracket_5"),
+        ],
+    )
+    def test_bracket_mapping(self, bracket: int, expected: int | None) -> None:
+        assert playgroup_bracket(bracket) == expected
+
+
+class TestFindLinkedPlayer:
+    def test_no_players(self) -> None:
+        game = create_mock_game()
+        assert find_linked_player(game) is None
+
+    def test_no_linked_players(self) -> None:
+        game = create_mock_game()
+        game.players = [create_mock_user(xid=100), create_mock_user(xid=200)]
+        assert find_linked_player(game) is None
+
+    def test_first_player_linked(self) -> None:
+        game = create_mock_game()
+        game.players = [create_mock_user(xid=100), create_mock_user(xid=200)]
+        game.players[0].playgroup_user_id = 42
+        assert find_linked_player(game) == 42
+
+    def test_second_player_linked(self) -> None:
+        game = create_mock_game()
+        game.players = [create_mock_user(xid=100), create_mock_user(xid=200)]
+        game.players[1].playgroup_user_id = 99
+        assert find_linked_player(game) == 99
+
+
+class TestLookupPlaygroupUser:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"id": 42, "username": "testplayer"}
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+        ):
+            user_id, username = await lookup_playgroup_user(mock_client, 123456789)
+
+        assert user_id == 42
+        assert username == "testplayer"
+        mock_client.get.assert_called_once()
+        call_url = mock_client.get.call_args[0][0]
+        assert "123456789" in call_url
+
+    @pytest.mark.asyncio
+    async def test_not_found(self) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+        ):
+            user_id, username = await lookup_playgroup_user(mock_client, 999)
+
+        assert user_id is None
+        assert username is None
+
+    @pytest.mark.asyncio
+    async def test_http_error(self) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server Error",
+                request=MagicMock(),
+                response=mock_response,
+            ),
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+        ):
+            user_id, username = await lookup_playgroup_user(mock_client, 123)
+
+        assert user_id is None
+        assert username is None
+
+    @pytest.mark.asyncio
+    async def test_network_error(self) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(side_effect=Exception("Connection refused"))
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+        ):
+            user_id, username = await lookup_playgroup_user(mock_client, 123)
+
+        assert user_id is None
+        assert username is None
+
+
+class TestFetchPlaygroupLiveSession:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"url": "https://playgroup.gg/live/abc123"}
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        game = create_mock_game(
+            game_id=42,
+            game_format=GameFormat.COMMANDER.value,
+            seats=4,
+            bracket=GameBracket.NONE.value,
+        )
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+        ):
+            result = await fetch_playgroup_live_session(mock_client, game, 42, 4)
+
+        assert result == {"url": "https://playgroup.gg/live/abc123"}
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["player_amount"] == 4
+        assert payload["life_amount"] == 40
+        assert payload["client_identifier"] == "spellbot"
+        assert payload["on_behalf_of_user_id"] == 42
+        assert "bracket" not in payload
+
+    @pytest.mark.asyncio
+    async def test_with_bracket(self) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"url": "https://playgroup.gg/live/xyz"}
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        game = create_mock_game(
+            game_id=42,
+            game_format=GameFormat.COMMANDER.value,
+            seats=4,
+            bracket=GameBracket.BRACKET_3.value,
+        )
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+        ):
+            await fetch_playgroup_live_session(mock_client, game, 42, 4)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["bracket"] == 3
+
+    @pytest.mark.asyncio
+    async def test_player_amount_capped_at_6(self) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"url": "https://playgroup.gg/live/big"}
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        game = create_mock_game(
+            game_id=42,
+            game_format=GameFormat.COMMANDER.value,
+            seats=10,
+            bracket=GameBracket.NONE.value,
+        )
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+        ):
+            await fetch_playgroup_live_session(mock_client, game, 42, 10)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["player_amount"] == 6
+
+
+class TestGenerateLink:
+    @pytest.mark.asyncio
+    async def test_no_api_key(self) -> None:
+        game = create_mock_game()
+
+        with patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", ""):
+            result = await generate_link(game)
+
+        assert result == (None, None)
+
+    @pytest.mark.asyncio
+    async def test_no_linked_player(self) -> None:
+        game = create_mock_game(service=GameService.PLAYGROUP_LIVE.value)
+        game.players = [create_mock_user(xid=100)]
+
+        with patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"):
+            result = await generate_link(game)
+
+        assert result == (None, None)
+
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        game = create_mock_game(
+            game_id=42,
+            game_format=GameFormat.COMMANDER.value,
+            service=GameService.PLAYGROUP_LIVE.value,
+            seats=4,
+            bracket=GameBracket.NONE.value,
+        )
+        host = create_mock_user(xid=100)
+        host.playgroup_user_id = 42
+        game.players = [host]
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module,
+                "fetch_playgroup_live_session",
+                AsyncMock(return_value={"url": "https://playgroup.gg/live/abc123"}),
+            ),
+        ):
+            result = await generate_link(game)
+
+        assert result == ("https://playgroup.gg/live/abc123", None)
+
+    @pytest.mark.asyncio
+    async def test_uses_original_seats(self) -> None:
+        game = create_mock_game(
+            game_id=42,
+            game_format=GameFormat.COMMANDER.value,
+            service=GameService.PLAYGROUP_LIVE.value,
+            seats=2,
+            bracket=GameBracket.NONE.value,
+        )
+        host = create_mock_user(xid=100)
+        host.playgroup_user_id = 42
+        game.players = [host]
+
+        mock_fetch = AsyncMock(return_value={"url": "https://playgroup.gg/live/abc123"})
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(playgroup_live_module, "fetch_playgroup_live_session", mock_fetch),
+        ):
+            result = await generate_link(game, original_seats=4)
+
+        assert result == ("https://playgroup.gg/live/abc123", None)
+        call_args = mock_fetch.call_args
+        assert call_args[0][3] == 4  # player_amount argument
+
+    @pytest.mark.asyncio
+    async def test_retries_on_failure_then_succeeds(self) -> None:
+        game = create_mock_game(
+            game_id=42,
+            game_format=GameFormat.COMMANDER.value,
+            service=GameService.PLAYGROUP_LIVE.value,
+            seats=4,
+            bracket=GameBracket.NONE.value,
+        )
+        host = create_mock_user(xid=100)
+        host.playgroup_user_id = 42
+        game.players = [host]
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"url": "https://playgroup.gg/live/retry"}
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(
+            side_effect=[Exception("Connection error"), mock_response],
+        )
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+            patch("httpx.AsyncClient") as mock_client_class,
+            patch.object(playgroup_live_module, "add_span_error"),
+        ):
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+            result = await generate_link(game)
+
+        assert result == ("https://playgroup.gg/live/retry", None)
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_fails_after_all_retries(self) -> None:
+        game = create_mock_game(
+            game_id=42,
+            game_format=GameFormat.COMMANDER.value,
+            service=GameService.PLAYGROUP_LIVE.value,
+            seats=4,
+            bracket=GameBracket.NONE.value,
+        )
+        host = create_mock_user(xid=100)
+        host.playgroup_user_id = 42
+        game.players = [host]
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(side_effect=Exception("Connection error"))
+
+        with (
+            patch.object(playgroup_live_module.settings, "PLAYGROUP_LIVE_API_KEY", "test-key"),
+            patch.object(
+                playgroup_live_module.settings,
+                "PLAYGROUP_LIVE_API_URL",
+                "https://playgroup.gg",
+            ),
+            patch("httpx.AsyncClient") as mock_client_class,
+            patch.object(playgroup_live_module, "add_span_error"),
+        ):
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+            result = await generate_link(game)
+
+        assert result == (None, None)
+        assert mock_client.post.call_count == playgroup_live_module.RETRY_ATTEMPTS

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -45,6 +45,7 @@ class TestModelUser:
             "updated_at": user1.updated_at,
             "name": user1.name,
             "banned": user1.banned,
+            "playgroup_user_id": None,
         }
 
         user2_data = user2.to_data()
@@ -55,6 +56,7 @@ class TestModelUser:
             "updated_at": user2.updated_at,
             "name": user2.name,
             "banned": user2.banned,
+            "playgroup_user_id": None,
         }
 
     async def test_pending_games(self, factories: Factories) -> None:


### PR DESCRIPTION
**Description**

Adds Playgroup Live (playgroup.gg) as a new game service. When a SpellBot game using the Playgroup Live service fills up, the bot creates a live session on playgroup.gg and posts the shareable URL.

A new "/playgroup link" slash command resolves a Discord user to their Playgroup user ID via the playgroup.gg API and stores it on the SpellBot user record. At least one player in the game must be linked for the session to be created; other players join via the URL without needing an account.

Key design choices:

- **Service-level API key** (PLAYGROUP_LIVE_API_KEY) The service appears in the "/lfg" picker only when the key is configured.
- **DB-backed `playgroup_user_id`** column on the users table, persists across restarts.
- **Force-start support**: "execute_start()" captures the original seat count before "shrink_game()" and passes it through to "generate_link()" so Playgroup's lobby has room for late joiners (capped at 6).
- Linking is checked in both "execute()" and "execute_start()"; if no player in the game has a linked account, players see a message to run "/playgroup link".

**Checklist**

- [x] Add tests for these changes
- [x] Test coverage is not decreased
- [x] Entire test suite passes
