### PR TITLE
Remove bold font weight from h1 headings

### DIFF
--- a/docs/assets/css/spellbot.css
+++ b/docs/assets/css/spellbot.css
@@ -1,3 +1,7 @@
+h1 {
+  font-weight: normal;
+}
+
 .hero {
   padding: 1rem;
   text-align: center;


### PR DESCRIPTION
**Description**

Updates the site's CSS to set `font-weight: normal` on `h1` elements, removing the default bold styling for top-level headings to improve visual appearance.

**Checklist**

- [ ] Add tests for these changes
- [ ] Test coverage is not decreased
- [ ] Entire test suite passes


---

<a href="https://builder.io/app/projects/a4bd68485a23468cb227/mega-order-xhmuup8h"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://a4bd68485a23468cb227-mega-order-xhmuup8h_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=a4bd68485a23468cb227&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2394`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a4bd68485a23468cb227</projectId>-->
<!--<branchName>mega-order-xhmuup8h</branchName>-->