### PR TITLE
Improve castlog report fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Post-game reports forwarded to castlog.gg now carry the SpellBot game id so castlog can tell a
+  re-report of a match it already has from a brand new match.
+- A post-game report that loses the stale-write guard is no longer forwarded to castlog.gg.
+- Post-game report `links` now accumulate across reports instead of being replaced, so a report
+  that only knows about one tracker no longer drops the others from the game detail page.
+
 ## [v21.9.0](https://github.com/lexicalunit/spellbot/releases/tag/v21.9.0) - 2026-08-29
 
 ### Added

--- a/src/spellbot/services/games.py
+++ b/src/spellbot/services/games.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime, timedelta
+from enum import Enum
 from typing import TYPE_CHECKING, cast
 
 from dateutil import tz
 from ddtrace.trace import tracer
-from sqlalchemy import TIMESTAMP, delete, func, select, update
+from sqlalchemy import TIMESTAMP, delete, func, literal, select, update
 from sqlalchemy import cast as sql_cast
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.dialects.postgresql import JSONB, insert
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import and_, asc, column, or_
 from sqlalchemy.sql.functions import count
@@ -67,18 +69,58 @@ def report_timestamp(metadata: dict[str, Any] | None) -> datetime | None:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
+class MetadataWrite(Enum):
+    """The outcome of a `set_metadata` call."""
+
+    APPLIED = "applied"
+    """The report was stored."""
+
+    STALE = "stale"
+    """The game exists, but a newer report is already stored, so this one was ignored."""
+
+    MISSING = "missing"
+    """No such game."""
+
+
+EMPTY_JSONB = sql_cast(literal("{}"), JSONB)
+
+
+def metadata_write_value(metadata: dict[str, Any]) -> Any:
+    """
+    Build the SQL value for a metadata write, accumulating `links` instead of replacing it.
+
+    Every key but `links` is last-write-wins. `links` is merged over what is already
+    stored because each writer only knows about its own trackers -- Convoke reports
+    `mythic_track`, SpellBot writes back `castlog` -- so a later report that simply
+    does not mention a link must not drop it from the game detail page.
+    """
+    incoming = sql_cast(literal(json.dumps(metadata)), JSONB)
+    stored_links = func.coalesce(
+        func.jsonb_extract_path(Game.game_metadata, "links"),
+        EMPTY_JSONB,
+    )
+    incoming_links = func.coalesce(func.jsonb_extract_path(incoming, "links"), EMPTY_JSONB)
+    merged_links = func.nullif(
+        stored_links.op("||", return_type=JSONB)(incoming_links),
+        EMPTY_JSONB,
+    )
+    # When neither side has any links, `nullif` yields NULL and `jsonb_strip_nulls` reduces
+    # `{"links": null}` to `{}`, so the merge becomes a no-op rather than storing an
+    # explicit null under `links`.
+    merge = func.jsonb_strip_nulls(func.jsonb_build_object("links", merged_links))
+    return incoming.op("||", return_type=JSONB)(merge)
+
+
 @tracer.wrap()
-async def set_metadata(game_id: int, metadata: dict[str, Any]) -> bool:
+async def set_metadata(game_id: int, metadata: dict[str, Any]) -> MetadataWrite:
     """
     Store the post-game report metadata for a game, replacing any prior report.
 
-    The store is last-write-wins, but a report that is strictly older than the one
-    already stored is accepted-and-ignored so a delayed write cannot clobber a
-    newer, richer report (both the automatic match-end report and the richer
-    post-game modal report race on this same row). The compare-and-set is done in a
-    single conditional `UPDATE` so it stays atomic under concurrent writes. Returns
-    `True` when the game exists (whether or not the report was applied),
-    `False` when it does not.
+    The store is last-write-wins (except for `links`, see `metadata_write_value`), but a
+    report that is strictly older than the one already stored is ignored so a delayed
+    write cannot clobber a newer, richer report (both the automatic match-end report and
+    the richer post-game modal report race on this same row). The compare-and-set is done
+    in a single conditional `UPDATE` so it stays atomic under concurrent writes.
     """
     new_ts = report_timestamp(metadata)
     conditions = [Game.id == game_id]
@@ -91,14 +133,16 @@ async def set_metadata(game_id: int, metadata: dict[str, Any]) -> bool:
         )
         conditions.append(or_(stored_ts.is_(None), stored_ts <= new_ts))
     result = await DatabaseSession.execute(
-        update(Game).where(*conditions).values(game_metadata=metadata),
+        update(Game).where(*conditions).values(game_metadata=metadata_write_value(metadata)),
     )
     await DatabaseSession.commit()
     if result.rowcount:
-        return True
-    # No row was updated: either the game does not exist, or a newer report already
-    # wins. Distinguish so the caller can return 404 vs. accepted-and-ignored.
-    return await DatabaseSession.scalar(select(Game.id).where(Game.id == game_id)) is not None
+        return MetadataWrite.APPLIED
+    # No row was updated: either the game does not exist, or a newer report already wins.
+    # Distinguish so the caller can return 404 vs. accepted-and-ignored.
+    if await DatabaseSession.scalar(select(Game.id).where(Game.id == game_id)) is None:
+        return MetadataWrite.MISSING
+    return MetadataWrite.STALE
 
 
 @tracer.wrap()

--- a/src/spellbot/web/api/rest.py
+++ b/src/spellbot/web/api/rest.py
@@ -17,6 +17,7 @@ from spellbot import services
 from spellbot.database import db_session_manager
 from spellbot.integrations import castlog
 from spellbot.metrics import add_span_request_id, generate_request_id
+from spellbot.services.games import MetadataWrite
 from spellbot.settings import settings
 from spellbot.web.tools import rate_limited
 
@@ -359,9 +360,17 @@ async def game_metadata_endpoint(request: web.Request) -> web.Response:
             return reply(error="Metadata must be a JSON object", status=400)
         if (error := sanitize_metadata(payload)) is not None:
             return reply(error=error, status=400)
-        if not await services.games.set_metadata(game_id, payload):
+        write = await services.games.set_metadata(game_id, payload)
+        if write is MetadataWrite.MISSING:
             return reply(error="Game not found", status=404)
-        castlog_data = await castlog.report_match(payload)
+        if write is MetadataWrite.STALE:
+            # A newer report already won locally, so forwarding this one would only make
+            # Castlog regress to data we have ourselves rejected.
+            return reply({"success": True})
+        # Castlog needs a stable key to tell a re-report of a match it already has from a
+        # brand new match. The game id only ever arrives in the URL, so add it here rather
+        # than trusting the reporter to include it in the body.
+        castlog_data = await castlog.report_match(payload | {"spellbot_game_id": game_id})
         castlog_url = castlog_data.get("castlog_url") if castlog_data else None
         if is_http_url(castlog_url):
             payload.setdefault("links", {})

--- a/tests/web/test_rest.py
+++ b/tests/web/test_rest.py
@@ -902,7 +902,79 @@ class TestGameMetadataEndpoint:
         )
 
         assert resp.status == 200
-        mock_report_match.assert_awaited_once_with(report)
+        # The game id only arrives in the URL, so it is added to the forwarded body to give
+        # Castlog a stable key for de-duplicating repeat reports of the same match.
+        mock_report_match.assert_awaited_once_with(report | {"spellbot_game_id": game.id})
+
+    async def test_game_metadata_does_not_forward_stale_report_to_castlog(
+        self,
+        client: ClientSession,
+        factories: Factories,
+        mocker: MockerFixture,
+    ) -> None:
+        guild = factories.guild.create(xid=2114, name="guild")
+        channel = factories.channel.create(xid=3114, name="channel", guild=guild)
+        game = factories.game.create(id=1114, seats=2, guild=guild, channel=channel)
+        token = factories.token.create(key="META14")
+        mock_report_match = mocker.patch(
+            "spellbot.web.api.rest.castlog.report_match",
+            new_callable=AsyncMock,
+            return_value=None,
+        )
+        headers = {"Authorization": f"Bearer {token.key}"}
+
+        newer = {"source": "convoke", "reported_at": "2026-07-11T18:30:00+00:00", "turns": 20}
+        older = {"source": "convoke", "reported_at": "2026-07-11T18:00:00+00:00", "turns": 5}
+
+        url = f"/api/game/{game.id}/metadata"
+        assert (await client.post(url, headers=headers, json=newer)).status == 200
+        assert (await client.post(url, headers=headers, json=older)).status == 200
+
+        # The older report is accepted-and-ignored locally, so Castlog must not be told
+        # about it either -- doing so would regress Castlog to data we rejected ourselves.
+        mock_report_match.assert_awaited_once_with(newer | {"spellbot_game_id": game.id})
+
+    async def test_game_metadata_accumulates_links_across_reports(
+        self,
+        client: ClientSession,
+        factories: Factories,
+    ) -> None:
+        guild = factories.guild.create(xid=2115, name="guild")
+        channel = factories.channel.create(xid=3115, name="channel", guild=guild)
+        game = factories.game.create(id=1115, seats=2, guild=guild, channel=channel)
+        token = factories.token.create(key="META15")
+        headers = {"Authorization": f"Bearer {token.key}"}
+
+        first = await client.post(
+            f"/api/game/{game.id}/metadata",
+            headers=headers,
+            json={
+                "source": "convoke",
+                "reported_at": "2026-07-11T18:00:00+00:00",
+                "links": {"mythic_track": "https://mythictrack.com/g/abc"},
+            },
+        )
+        assert first.status == 200
+        # A later report that only knows about its own tracker must not drop the other link.
+        second = await client.post(
+            f"/api/game/{game.id}/metadata",
+            headers=headers,
+            json={
+                "source": "convoke",
+                "reported_at": "2026-07-11T18:30:00+00:00",
+                "links": {"castlog": "https://app.castlog.gg/match/abc-123"},
+            },
+        )
+        assert second.status == 200
+
+        from spellbot import services  # allow_inline
+
+        detail = await services.games.game_detail_view(game.id)
+        assert detail is not None
+        assert detail["metadata"]["links"] == {
+            "mythic_track": "https://mythictrack.com/g/abc",
+            "castlog": "https://app.castlog.gg/match/abc-123",
+        }
 
     async def test_game_metadata_survives_castlog_failure(
         self,


### PR DESCRIPTION
## Context

Castlog reported seeing games where every player `xid` is null and no winner is set. The root cause of the null xids is on the Convoke side (see the companion PR in `commander-online`), but investigating turned up three real problems on this side of the wire.

## Changes

**Forward the SpellBot game id to castlog.** `report_match` sends the request body through verbatim, and the game id only ever arrives in the URL path. So castlog had no way to tell a re-report of a match it already has from a brand new match — a single game legitimately produces several reports (the automatic match-end one, a later winner finalization, the post-game modal). The id is injected into the outbound body rather than trusted from the reporter's payload, since we know it authoritatively.

**Don't forward a report that lost the stale-write guard.** `set_metadata` returned `True` whenever the game existed, whether or not the write applied — conflating "stored" with "accepted and ignored as stale". The endpoint then called castlog unconditionally, so a delayed or out-of-order report we had just rejected locally still got pushed to castlog. It now returns which of the three outcomes happened (`APPLIED` / `STALE` / `MISSING`) and the forward is skipped on `STALE`.

**Accumulate `links` across reports instead of replacing them.** Each writer only knows about its own trackers — Convoke reports `mythic_track`, SpellBot writes back `castlog` — so a later report that simply omits a link would drop it from the game detail page. The merge happens inside the existing conditional `UPDATE` so the compare-and-set stays atomic. Everything outside `links` is still last-write-wins.

## Testing

`uv run pytest -n3` — 1708 passed. Three new cases cover the stale-report forward being skipped, the game id reaching castlog, and links accumulating across reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)